### PR TITLE
Rename the CLI tool from "dtm" to "dsm"

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.29
+          args: --timeout 3m0s

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.dylib
 
 # build
-/dtm
+/dsm
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ build:
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/githubactions_0.0.1.so ./cmd/githubactions/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocd_0.0.1.so ./cmd/argocd/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocdapp_0.0.1.so ./cmd/argocdapp/
-	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
+	go build -trimpath -gcflags="all=-N -l" -o dsm ./cmd/devstream/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## DevStream, What Is It Anyway?
 
-DevStream is an open-source DevOps tool manager (DTM).
+DevStream is an open-source DevOps tool manager.
 
 Imagine you are in a new project. Before writing the first line of code, you would have to figure out the tools needed in the whole Software Development Life Cycle (SDLC). You would probably need the following pieces:
 
@@ -35,7 +35,7 @@ And, there are multiple challenges in creating YOUR ideal SDLC workflow:
 
 To be fair, there are a few integrated products out there that may contain everything you might need, but they might not suit your specific requirements perfectly. So, the chance is, you will still want to go out and do your research, find the best pieces for you, and integrate them. And, it would be a lot of operational overhead if all you had to do all day was install and uninstall and integrate things.
 
-You probably have already seen where we are going with this, and you are right: DevStream, an open-source DevOps tool manager (DTM), aims to be the solution here.
+You probably have already seen where we are going with this, and you are right: DevStream, an open-source DevOps tool manager, aims to be the solution here.
 
 Think of the Linux kernel V.S. different distributions. Different distros offer different packages so that you can always choose the best for your need.
 
@@ -67,8 +67,10 @@ See [examples/config.yaml](./examples/config.yaml).
 
 ## Run
 
+The CLI tool is named `dsm`, which is short for DevStream:
+
 ```bash
-./dtm install -f examples/config.yaml
+./dsm install -f examples/config.yaml
 ```
 
 ## Contribute

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -10,7 +10,7 @@ var (
 	configFile string
 
 	rootCMD = &cobra.Command{
-		Use:   "dtm",
+		Use:   "dsm",
 		Short: "DevStream is an open-source DevOps tool manager",
 		Long:  `DevStream is an open-source DevOps tool manager`,
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,9 +10,11 @@ The following diagram shows an approximation of how DevStream executes a user co
 
 ## CLI (The `devstream` Package)
 
-Every time a user runs the `dtm` program, the execution transfers immediately into one of the "command" implementations in the [`devstream`](https://github.com/merico-dev/stream/tree/main/cmd/devstream) package, in which folder all commands' definitions reside. Then, each command calls the corresponding package under [`internal/pkg`](https://github.com/merico-dev/stream/tree/main/internal/pkg).
+For simplicity, the CLI is named `dsm` instead of the full name DevStream.
 
-The flow illustrated above applies to the main DevStream commands like `dtm install`, `dtm uninstall` (_TODO_), and `dtm reinstall` (_TODO_). For these commands, the role of the command is to parse all the config, load each plugin, and call the [predefined interface](https://github.com/merico-dev/stream/blob/main/internal/pkg/plugin/plugin.go#L12).
+Every time a user runs the `dsm` program, the execution transfers immediately into one of the "command" implementations in the [`devstream`](https://github.com/merico-dev/stream/tree/main/cmd/devstream) package, in which folder all commands' definitions reside. Then, each command calls the corresponding package under [`internal/pkg`](https://github.com/merico-dev/stream/tree/main/internal/pkg).
+
+The flow illustrated above applies to the main DevStream commands like `dsm install`, `dsm uninstall` (_TODO_), and `dsm reinstall` (_TODO_). For these commands, the role of the command is to parse all the config, load each plugin, and call the [predefined interface](https://github.com/merico-dev/stream/blob/main/internal/pkg/plugin/plugin.go#L12).
 
 ## Configuration Loader
 


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.
- [x] Documentation (new or existing) is updated.

## Description

- CLI tool is renamed from `dtm` to `dsm`.
- Documentation is updated, too.

### Current Behavior

`dtm install -f ...`

### New Behavior

`dsm install -f ...`
