### PR TITLE
fix: some reflactoring with download-client/plugin-engine

### DIFF
--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -13,13 +13,13 @@ func DownloadPlugins(conf *configloader.Config) error {
 	pluginsDir := filepath.Join(".", "plugins")
 
 	// download all plugins that don't exist locally
-	client := NewDownloadClient()
+	dc := NewDownloadClient()
 
 	for _, tool := range conf.Tools {
 		pluginFileName := configloader.GetPluginFileName(&tool)
 		if _, err := os.Stat(filepath.Join(pluginsDir, pluginFileName)); errors.Is(err, os.ErrNotExist) {
 			// plugin does not exist
-			err := client.download(pluginsDir, pluginFileName, tool.Version)
+			err := dc.download(pluginsDir, pluginFileName, tool.Version)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>


# Summary

some reflactoring with download-client/plugin-engine

## Key Points

- [ ] This is a breaking change.
- [ ] Documentation (new or existing) is updated.

## Description

- All params in DownloadClient is not used without retry.Client. So they can be removed and retry.Client.SetRetryCount() is needed.
- Impreved some exception handling.

/kind reflector
/kind bug
/cc @merico-dev/devstream please take a review at this pr. thx.