### PR TITLE
refactor: make Makefile better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-build: ## Build dtm & plugins locally.
-	go get ./...
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+build: fmt vet ## Build dtm & plugins locally.
+	go mod tidy
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/githubactions_0.0.1.so ./cmd/githubactions/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocd_0.0.1.so ./cmd/argocd/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocdapp_0.0.1.so ./cmd/argocdapp/
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
-build-core: ## Build dtm core only, locally.
-	go get ./...
+build-core: fmt vet ## Build dtm core only, locally.
+	go mod tidy
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
 fmt: ## Run go fmt against code.
+	go get golang.org/x/tools/cmd/goimports
 	goimports -local="github.com/merico-dev/stream" -d -w cmd
 	goimports -local="github.com/merico-dev/stream" -d -w internal
 	go fmt ./...


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

make Makefile better

## Description

1. Use `go mod tidy` to instead of `go get ./...`. `go mod tidy` contains the work of `go get ./...` and does more.

Tidy makes sure go.mod matches the source code in the module.
It adds any missing modules necessary to build the current module's
packages and dependencies, and it removes unused modules that
don't provide any relevant packages. It also adds any missing entries
to go.sum and removes any unnecessary ones.

2. Add `make help` command, effect like below:

![image](https://user-images.githubusercontent.com/18692628/147438819-4c1fc6dc-c295-400e-9f22-081e0101d6b1.png)

3. Add **fmt** and **vet** as two default action in `build` stage.

![image](https://user-images.githubusercontent.com/18692628/147439025-ec5ebafc-1865-4879-b343-21c1339a6afa.png)
