### PR TITLE
Feat: Use viper to read in the config.yaml

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
@@ -21,10 +22,16 @@ DevStream will generate and execute a new plan based on the config file and the 
 }
 
 func applyCMDFunc(cmd *cobra.Command, args []string) {
-	conf := configloader.LoadConf(configFile)
+	var tools = make([]configloader.Tool, 0)
+	if err := viper.UnmarshalKey("tools", &tools); err != nil {
+		log.Fatal(err)
+	}
+	var cfg = &configloader.Config{
+		Tools: tools,
+	}
 
 	// init before installation
-	err := pluginmanager.DownloadPlugins(conf)
+	err := pluginmanager.DownloadPlugins(cfg)
 	if err != nil {
 		log.Printf("Error: %s", err)
 		return
@@ -37,7 +44,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 	}
 	smgr := statemanager.NewManager(b)
 
-	p := planmanager.NewPlan(smgr, conf)
+	p := planmanager.NewPlan(smgr, cfg)
 	if len(p.Changes) == 0 {
 		log.Println("it is nothing to do here")
 		return

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/spf13/viper"
+
 	"github.com/spf13/cobra"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
@@ -17,8 +19,15 @@ var initCMD = &cobra.Command{
 }
 
 func initCMDFunc(cmd *cobra.Command, args []string) {
-	conf := configloader.LoadConf(configFile)
-	err := pluginmanager.DownloadPlugins(conf)
+	var tools = make([]configloader.Tool, 0)
+	if err := viper.UnmarshalKey("tools", &tools); err != nil {
+		log.Fatal(err)
+	}
+	var cfg = &configloader.Config{
+		Tools: tools,
+	}
+
+	err := pluginmanager.DownloadPlugins(cfg)
 	if err != nil {
 		log.Printf("Error: %s", err)
 		return

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -21,7 +21,7 @@ var (
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "", "config file")
 	rootCMD.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "p", ".devstream/plugins", "plugins directory")
 
 	rootCMD.AddCommand(versionCMD)
@@ -30,6 +30,17 @@ func init() {
 }
 
 func initConfig() {
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	} else {
+		viper.AddConfigPath(".")
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("config")
+	}
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
+
 	viper.AutomaticEnv()
 	if err := viper.BindEnv("github_token"); err != nil {
 		log.Fatal(err)

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -2,10 +2,6 @@ package configloader
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
-
-	"gopkg.in/yaml.v3"
 )
 
 // Config is the struct for loading DevStream configuration YAML files.
@@ -30,23 +26,6 @@ func (t *Tool) DeepCopy() *Tool {
 		retTool.Options[k] = v
 	}
 	return &retTool
-}
-
-// LoadConf reads an input file as a Config struct.
-func LoadConf(fname string) *Config {
-	f, err := ioutil.ReadFile(fname)
-	if err != nil {
-		log.Print("It seems you don't have a config file. Maybe you have it in another directory and forgot to use the -f option? See dtm -h for more help.")
-		log.Fatal(err)
-	}
-
-	conf := Config{}
-	err = yaml.Unmarshal(f, &conf)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return &conf
 }
 
 // GetPluginFileName creates the file name based on the tool's name and version

--- a/internal/pkg/pluginmanager/pbdownloader.go
+++ b/internal/pkg/pluginmanager/pbdownloader.go
@@ -109,7 +109,7 @@ func createPathIfNotExists(path string) error {
 	if !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.Mkdir(path, os.ModePerm); err != nil {
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Use viper to read in the config.yaml

### Related Issues

It's useful for #64 