### PR TITLE
refactor: cmd and plugin engine modules, and fixing some bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dtm
 
 # .devstream
 .devstream/
+devstream.state

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ help: ## Display this help.
 
 build: fmt vet ## Build dtm & plugins locally.
 	go mod tidy
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/githubactions_0.0.1.so ./cmd/githubactions/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocd_0.0.1.so ./cmd/argocd/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o plugins/argocdapp_0.0.1.so ./cmd/argocdapp/
+	mkdir -p .devstream
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions_0.0.1.so ./cmd/githubactions/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd_0.0.1.so ./cmd/argocd/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp_0.0.1.so ./cmd/argocdapp/
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
 build-core: fmt vet ## Build dtm core only, locally.
@@ -13,7 +14,7 @@ build-core: fmt vet ## Build dtm core only, locally.
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
 fmt: ## Run 'go fmt' & goimports against code.
-	go get golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@latest
 	goimports -local="github.com/merico-dev/stream" -d -w cmd
 	goimports -local="github.com/merico-dev/stream" -d -w internal
 	go fmt ./...

--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -4,13 +4,8 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	"github.com/merico-dev/stream/internal/pkg/backend"
-	"github.com/merico-dev/stream/internal/pkg/configloader"
-	"github.com/merico-dev/stream/internal/pkg/planmanager"
-	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
-	"github.com/merico-dev/stream/internal/pkg/statemanager"
+	"github.com/merico-dev/stream/internal/pkg/pluginengine"
 )
 
 var applyCMD = &cobra.Command{
@@ -22,44 +17,7 @@ DevStream will generate and execute a new plan based on the config file and the 
 }
 
 func applyCMDFunc(cmd *cobra.Command, args []string) {
-	var tools = make([]configloader.Tool, 0)
-	if err := viper.UnmarshalKey("tools", &tools); err != nil {
-		log.Fatal(err)
-	}
-	var cfg = &configloader.Config{
-		Tools: tools,
-	}
-
-	// init before installation
-	err := pluginmanager.DownloadPlugins(cfg)
-	if err != nil {
-		log.Printf("Error: %s", err)
-		return
-	}
-
-	// use default local backend for now.
-	b, err := backend.GetBackend("local")
-	if err != nil {
-		log.Fatal(err)
-	}
-	smgr := statemanager.NewManager(b)
-
-	p := planmanager.NewPlan(smgr, cfg)
-	if len(p.Changes) == 0 {
-		log.Println("it is nothing to do here")
-		return
-	}
-
-	errsMap := p.Execute()
-	if len(errsMap) == 0 {
-		log.Println("=== all plugins Install/Uninstall/Reinstall process succeeded ===")
-		log.Println("=== END ===")
-		return
-	}
-
-	log.Println("=== some errors occurred during plugins Install/Uninstall/Reinstall process ===")
-	for k, err := range errsMap {
-		log.Printf("%s -> %s", k, err)
-	}
-	log.Println("=== END ===")
+	log.Println("Apply started.")
+	pluginengine.Run(configFile)
+	log.Println("Apply finished.")
 }

--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +19,12 @@ DevStream will generate and execute a new plan based on the config file and the 
 
 func applyCMDFunc(cmd *cobra.Command, args []string) {
 	log.Println("Apply started.")
-	pluginengine.Run(configFile)
+
+	err := pluginengine.Run(configFile)
+	if err != nil {
+		log.Printf("Apply error: %s.", err)
+		os.Exit(1)
+	}
+
 	log.Println("Apply finished.")
 }

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -22,7 +22,7 @@ func initCMDFunc(cmd *cobra.Command, args []string) {
 	log.Println("Initialize started.")
 	err := pluginmanager.DownloadPlugins(cfg)
 	if err != nil {
-		log.Printf("Error: %s", err)
+		log.Printf("Error: %s.", err)
 		return
 	}
 

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -3,8 +3,6 @@ package main
 import (
 	"log"
 
-	"github.com/spf13/viper"
-
 	"github.com/spf13/cobra"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
@@ -19,18 +17,14 @@ var initCMD = &cobra.Command{
 }
 
 func initCMDFunc(cmd *cobra.Command, args []string) {
-	var tools = make([]configloader.Tool, 0)
-	if err := viper.UnmarshalKey("tools", &tools); err != nil {
-		log.Fatal(err)
-	}
-	var cfg = &configloader.Config{
-		Tools: tools,
-	}
+	cfg := configloader.LoadConf(configFile)
 
+	log.Println("Initialize started.")
 	err := pluginmanager.DownloadPlugins(cfg)
 	if err != nil {
 		log.Printf("Error: %s", err)
 		return
 	}
-	log.Println("=== initialize finished ===")
+
+	log.Println("Initialize finished.")
 }

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -21,8 +21,8 @@ var (
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "", "config file")
-	rootCMD.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "p", ".devstream/plugins", "plugins directory")
+	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	rootCMD.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "p", ".devstream/", "plugins directory")
 
 	rootCMD.AddCommand(versionCMD)
 	rootCMD.AddCommand(initCMD)
@@ -30,17 +30,6 @@ func init() {
 }
 
 func initConfig() {
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-	} else {
-		viper.AddConfigPath(".")
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("config")
-	}
-	if err := viper.ReadInConfig(); err != nil {
-		log.Fatal(err)
-	}
-
 	viper.AutomaticEnv()
 	if err := viper.BindEnv("github_token"); err != nil {
 		log.Fatal(err)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -9,8 +9,8 @@ tools:
       name: go
       version: "1.17"
     branch: master
-##for python config
-#- name: githubactions
+# # for python config
+# - name: githubactions
 #  version: 0.0.1
 #  options:
 #    owner: lfbdev
@@ -19,8 +19,8 @@ tools:
 #      name: python
 #      version: "3"
 #    branch: master
-##for nodejs config
-#- name: githubactions
+# # for nodejs config
+# - name: githubactions
 #  version: 0.0.1
 #  options:
 #    owner: lfbdev

--- a/internal/pkg/backend/local/local.go
+++ b/internal/pkg/backend/local/local.go
@@ -1,13 +1,15 @@
 package local
 
 import (
+	"errors"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
 )
 
-const DefaultStateFile = ".devstream/devstream.state"
+const DefaultStateFile = "devstream.state"
 
 // Local is a default implement for backend.Backend
 type Local struct {
@@ -21,6 +23,15 @@ func NewLocal(filename string) *Local {
 	if filename == "" {
 		lFile = DefaultStateFile
 	}
+
+	if _, err := os.Stat(lFile); errors.Is(err, os.ErrNotExist) {
+		file, err := os.Create(lFile)
+		if err != nil {
+			log.Fatalf("Creating state file %s failed.", lFile)
+		}
+		defer file.Close()
+	}
+
 	return &Local{
 		filename: lFile,
 	}

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -2,6 +2,9 @@ package configloader
 
 import (
 	"fmt"
+	"log"
+
+	"github.com/spf13/viper"
 )
 
 // Config is the struct for loading DevStream configuration YAML files.
@@ -26,6 +29,31 @@ func (t *Tool) DeepCopy() *Tool {
 		retTool.Options[k] = v
 	}
 	return &retTool
+}
+
+// LoadConf reads an input file as a Config struct.
+func LoadConf(fname string) *Config {
+	if fname != "" {
+		viper.SetConfigFile(fname)
+	} else {
+		viper.AddConfigPath(".")
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("config")
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
+		log.Print(err)
+		log.Print("Perhaps you forgot to specify the path of the config file by using the \"-f\" parameter?")
+		log.Fatal("See more help by running \"dtm help\"")
+	}
+
+	var tools = make([]Tool, 0)
+
+	if err := viper.UnmarshalKey("tools", &tools); err != nil {
+		log.Fatal(err)
+	}
+
+	return &Config{Tools: tools}
 }
 
 // GetPluginFileName creates the file name based on the tool's name and version

--- a/internal/pkg/planmanager/change.go
+++ b/internal/pkg/planmanager/change.go
@@ -5,15 +5,10 @@ import (
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
-// ActionFunc is a function that Do Action with a plugin. like:
-// plugin.Install() / plugin.Reinstall() / plugin.Uninstall()
-type ActionFunc func(tool *configloader.Tool) (bool, error)
-
 // Change is a wrapper with a single Tool and its Action should be execute.
 type Change struct {
 	Tool       *configloader.Tool
 	ActionName statemanager.ComponentAction
-	Action     ActionFunc
 	Result     *ChangeResult
 }
 

--- a/internal/pkg/planmanager/plan.go
+++ b/internal/pkg/planmanager/plan.go
@@ -1,9 +1,7 @@
 package planmanager
 
 import (
-	"fmt"
 	"log"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -29,16 +27,16 @@ func NewPlan(smgr statemanager.Manager, cfg *configloader.Config) *Plan {
 		statesMap := statemanager.NewStatesMap()
 		tmpMap := make(map[string]*statemanager.State)
 		if err := yaml.Unmarshal(data, tmpMap); err != nil {
-			log.Printf("devstream.statesMap format error")
+			log.Fatalf("Devstream.statesMap format error.")
 			return &Plan{Changes: make([]*Change, 0)}
 		}
 		for k, v := range tmpMap {
 			statesMap.Store(k, v)
 		}
 		smgr.SetStatesMap(statesMap)
-		log.Println("succeeded to initialize StatesMap")
+		log.Printf("Succeeded initializing StatesMap.")
 	} else {
-		log.Printf("failed to initialize StatesMap. Error: (%s). try to initialize the StatesMap", err)
+		log.Printf("Failed to initialize StatesMap. Error: (%s). Try to initialize the StatesMap.", err)
 	}
 
 	plan := &Plan{
@@ -46,39 +44,8 @@ func NewPlan(smgr statemanager.Manager, cfg *configloader.Config) *Plan {
 		smgr:    smgr,
 	}
 	tmpStates := smgr.GetStatesMap().DeepCopy()
-
 	plan.generatePlanAccordingToConfig(tmpStates, cfg)
 	plan.removeNoLongerNeededToolsFromPlan(tmpStates)
 
 	return plan
-}
-
-// Execute will execute all changes included in the Plan and record results.
-// All errors will be return.
-func (p *Plan) Execute() map[string]error {
-	errorsMap := make(map[string]error)
-	log.Printf("changes count: %d", len(p.Changes))
-	for i, c := range p.Changes {
-		log.Printf("processing progress: %d/%d", i+1, len(p.Changes))
-		log.Printf("processing: %s -> %s", c.Tool.Name, c.ActionName)
-		// We will consider how to execute Action concurrently later.
-		// It involves dependency management.
-		succeeded, err := c.Action(c.Tool)
-		if err != nil {
-			key := fmt.Sprintf("%s-%s", c.Tool.Name, c.ActionName)
-			errorsMap[key] = err
-		}
-
-		c.Result = &ChangeResult{
-			Succeeded: succeeded,
-			Error:     err,
-			Time:      time.Now().Format(time.RFC3339),
-		}
-
-		err = p.handleResult(c)
-		if err != nil {
-			errorsMap["handle-result"] = err
-		}
-	}
-	return errorsMap
 }

--- a/internal/pkg/planmanager/plan_helper.go
+++ b/internal/pkg/planmanager/plan_helper.go
@@ -1,0 +1,61 @@
+package planmanager
+
+import (
+	"log"
+
+	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/statemanager"
+)
+
+// generatePlanAccordingToConfig is to filter all the Tools in cfg that need some actions
+func (p *Plan) generatePlanAccordingToConfig(statesMap *statemanager.StatesMap, cfg *configloader.Config) {
+	for _, tool := range cfg.Tools {
+		state := p.smgr.GetState(tool.Name)
+		if state == nil {
+			p.Changes = append(p.Changes, &Change{
+				Tool:       tool.DeepCopy(),
+				ActionName: statemanager.ActionInstall,
+			})
+			log.Printf("Change added: %s -> %s", tool.Name, statemanager.ActionInstall)
+			continue
+		}
+
+		switch state.Status {
+		case statemanager.StatusUninstalled:
+			p.Changes = append(p.Changes, &Change{
+				Tool:       tool.DeepCopy(),
+				ActionName: statemanager.ActionInstall,
+			})
+			log.Printf("Change added: %s -> %s", tool.Name, statemanager.ActionInstall)
+		case statemanager.StatusFailed:
+			p.Changes = append(p.Changes, &Change{
+				Tool:       tool.DeepCopy(),
+				ActionName: statemanager.ActionReinstall,
+			})
+			log.Printf("Change added: %s -> %s", tool.Name, statemanager.ActionReinstall)
+		case statemanager.StatusRunning:
+			p.Changes = append(p.Changes, &Change{
+				Tool:       tool.DeepCopy(),
+				ActionName: statemanager.ActionInstall,
+			})
+			log.Printf("Change added: %s -> %s", tool.Name, statemanager.ActionInstall)
+		}
+		statesMap.Delete(tool.Name)
+	}
+}
+
+// Some tools have already been installed, but they are no longer needed, so they need to be uninstalled
+func (p *Plan) removeNoLongerNeededToolsFromPlan(statesMap *statemanager.StatesMap) {
+	statesMap.Range(func(key, value interface{}) bool {
+		p.Changes = append(p.Changes, &Change{
+			Tool: &configloader.Tool{
+				Name:    key.(string),
+				Version: value.(*statemanager.State).Version,
+				Options: value.(*statemanager.State).LastOperation.Metadata,
+			},
+			ActionName: statemanager.ActionUninstall,
+		})
+		log.Printf("Change added: %s -> %s", key.(string), statemanager.ActionUninstall)
+		return true
+	})
+}

--- a/internal/pkg/plugin/argocd/argocd.go
+++ b/internal/pkg/plugin/argocd/argocd.go
@@ -53,7 +53,7 @@ func (a *ArgoCD) addHelmRepo() error {
 }
 
 func (a *ArgoCD) installOrUpgradeHelmChart() error {
-	log.Println("adding and updating argocd helm chart repo")
+	log.Println("Adding and updating argocd helm chart repo ...")
 	if err := a.addHelmRepo(); err != nil {
 		return err
 	}

--- a/internal/pkg/plugin/argocd/install.go
+++ b/internal/pkg/plugin/argocd/install.go
@@ -11,7 +11,7 @@ func Install(options *map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
-	log.Println("installing or updating argocd helm chart")
+	log.Println("Installing or updating argocd helm chart ...")
 	if err := acd.installOrUpgradeHelmChart(); err != nil {
 		return false, err
 	}

--- a/internal/pkg/plugin/argocdapp/template.go
+++ b/internal/pkg/plugin/argocdapp/template.go
@@ -6,6 +6,8 @@ kind: Application
 metadata:
   name: {{.App.Name}}
   namespace: {{.App.Namespace}}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: {{.Destination.Namespace}}

--- a/internal/pkg/plugin/githubactions/githubactions.go
+++ b/internal/pkg/plugin/githubactions/githubactions.go
@@ -50,7 +50,7 @@ func (ga *GithubActions) AddWorkflow(workflow *Workflow) error {
 		return err
 	}
 	if sha != "" {
-		log.Printf("github actions Workflow %s already exists\n", workflow.workflowFileName)
+		log.Printf("GitHub Actions workflow %s already exists.", workflow.workflowFileName)
 		return nil
 	}
 
@@ -62,7 +62,7 @@ func (ga *GithubActions) AddWorkflow(workflow *Workflow) error {
 		Branch:  github.String(ga.options.Branch),
 	}
 
-	log.Printf("creating github actions Workflow %s...\n", workflow.workflowFileName)
+	log.Printf("Creating GitHub Actions workflow %s ...", workflow.workflowFileName)
 	_, _, err = ga.client.Repositories.CreateFile(
 		ga.ctx,
 		ga.options.Owner,
@@ -73,7 +73,7 @@ func (ga *GithubActions) AddWorkflow(workflow *Workflow) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("github actions Workflow %s created\n", workflow.workflowFileName)
+	log.Printf("Github Actions workflow %s created.", workflow.workflowFileName)
 	return nil
 }
 
@@ -83,7 +83,7 @@ func (ga *GithubActions) DeleteWorkflow(workflow *Workflow) error {
 		return err
 	}
 	if sha == "" {
-		log.Printf("github actions Workflow %s already removed\n", workflow.workflowFileName)
+		log.Printf("Github Actions workflow %s already removed.", workflow.workflowFileName)
 		return nil
 	}
 
@@ -95,7 +95,7 @@ func (ga *GithubActions) DeleteWorkflow(workflow *Workflow) error {
 		Branch:  github.String(ga.options.Branch),
 	}
 
-	log.Printf("deleting github actions Workflow %s...\n", workflow.workflowFileName)
+	log.Printf("Deleting GitHub Actions workflow %s ...", workflow.workflowFileName)
 	_, _, err = ga.client.Repositories.DeleteFile(
 		ga.ctx,
 		ga.options.Owner,
@@ -106,7 +106,7 @@ func (ga *GithubActions) DeleteWorkflow(workflow *Workflow) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("github actions Workflow %s removed\n", workflow.workflowFileName)
+	log.Printf("GitHub Actions workflow %s removed.", workflow.workflowFileName)
 	return nil
 }
 

--- a/internal/pkg/plugin/githubactions/install.go
+++ b/internal/pkg/plugin/githubactions/install.go
@@ -10,7 +10,7 @@ func Install(options *map[string]interface{}) (bool, error) {
 	}
 
 	language := githubActions.GetLanguage()
-	log.Printf("language is %s", language.String())
+	log.Printf("Language is: %s.", language.String())
 	ws := defaultWorkflows.GetWorkflowByNameVersionTypeString(language.String())
 
 	for _, pipeline := range ws {

--- a/internal/pkg/pluginengine/engine.go
+++ b/internal/pkg/pluginengine/engine.go
@@ -1,6 +1,7 @@
 package pluginengine
 
 import (
+	"errors"
 	"log"
 
 	"github.com/merico-dev/stream/internal/pkg/backend"
@@ -10,37 +11,38 @@ import (
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
-func Run(fname string) {
+func Run(fname string) error {
 	cfg := configloader.LoadConf(fname)
 
 	// init before installation
 	err := pluginmanager.DownloadPlugins(cfg)
 	if err != nil {
-		log.Printf("Error: %s", err)
-		return
+		return err
 	}
 
 	// use default local backend for now.
 	b, err := backend.GetBackend("local")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
 	smgr := statemanager.NewManager(b)
 
 	p := planmanager.NewPlan(smgr, cfg)
 	if len(p.Changes) == 0 {
 		log.Println("No changes done since last apply. There is nothing to do.")
-		return
+		return nil
 	}
 
 	errsMap := execute(p)
-	if len(errsMap) == 0 {
-		log.Println("All plugins applied successfully.")
-		return
+	if len(errsMap) != 0 {
+		err := errors.New("some error(s) occurred during plugins apply process")
+		for k, e := range errsMap {
+			log.Printf("%s -> %s", k, e)
+		}
+		return err
 	}
 
-	log.Println("Some errors occurred during plugins apply process.")
-	for k, err := range errsMap {
-		log.Printf("%s -> %s", k, err)
-	}
+	log.Println("All plugins applied successfully.")
+	return nil
 }

--- a/internal/pkg/pluginengine/engine.go
+++ b/internal/pkg/pluginengine/engine.go
@@ -1,0 +1,46 @@
+package pluginengine
+
+import (
+	"log"
+
+	"github.com/merico-dev/stream/internal/pkg/backend"
+	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/planmanager"
+	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
+	"github.com/merico-dev/stream/internal/pkg/statemanager"
+)
+
+func Run(fname string) {
+	cfg := configloader.LoadConf(fname)
+
+	// init before installation
+	err := pluginmanager.DownloadPlugins(cfg)
+	if err != nil {
+		log.Printf("Error: %s", err)
+		return
+	}
+
+	// use default local backend for now.
+	b, err := backend.GetBackend("local")
+	if err != nil {
+		log.Fatal(err)
+	}
+	smgr := statemanager.NewManager(b)
+
+	p := planmanager.NewPlan(smgr, cfg)
+	if len(p.Changes) == 0 {
+		log.Println("No changes done since last apply. There is nothing to do.")
+		return
+	}
+
+	errsMap := execute(p)
+	if len(errsMap) == 0 {
+		log.Println("All plugins applied successfully.")
+		return
+	}
+
+	log.Println("Some errors occurred during plugins apply process.")
+	for k, err := range errsMap {
+		log.Printf("%s -> %s", k, err)
+	}
+}

--- a/internal/pkg/pluginengine/helper.go
+++ b/internal/pkg/pluginengine/helper.go
@@ -1,0 +1,81 @@
+package pluginengine
+
+import (
+	"fmt"
+	"log"
+	"plugin"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/planmanager"
+	"github.com/merico-dev/stream/internal/pkg/statemanager"
+)
+
+func loadPlugin(tool *configloader.Tool) (DevStreamPlugin, error) {
+	pluginDir := viper.GetString("plugin-dir")
+	if pluginDir == "" {
+		return nil, fmt.Errorf("plugin-dir is \"\"")
+	}
+
+	mod := fmt.Sprintf("%s/%s_%s.so", pluginDir, tool.Name, tool.Version)
+	plug, err := plugin.Open(mod)
+	if err != nil {
+		return nil, err
+	}
+
+	var devStreamPlugin DevStreamPlugin
+	symDevStreamPlugin, err := plug.Lookup("DevStreamPlugin")
+	if err != nil {
+		return nil, err
+	}
+
+	devStreamPlugin, ok := symDevStreamPlugin.(DevStreamPlugin)
+	if !ok {
+		return nil, err
+	}
+
+	return devStreamPlugin, nil
+}
+
+func execute(p *planmanager.Plan) map[string]error {
+	errorsMap := make(map[string]error)
+
+	log.Printf("Changes count: %d.", len(p.Changes))
+
+	for i, c := range p.Changes {
+		log.Printf("Processing progress: %d/%d.", i+1, len(p.Changes))
+		log.Printf("Processing: %s -> %s ...", c.Tool.Name, c.ActionName)
+
+		var succeeded bool
+		var err error
+
+		switch c.ActionName {
+		case statemanager.ActionInstall:
+			succeeded, err = Install(c.Tool)
+		case statemanager.ActionReinstall:
+			succeeded, err = Reinstall(c.Tool)
+		case statemanager.ActionUninstall:
+			succeeded, err = Uninstall(c.Tool)
+		}
+
+		if err != nil {
+			key := fmt.Sprintf("%s-%s", c.Tool.Name, c.ActionName)
+			errorsMap[key] = err
+		}
+
+		c.Result = &planmanager.ChangeResult{
+			Succeeded: succeeded,
+			Error:     err,
+			Time:      time.Now().Format(time.RFC3339),
+		}
+
+		err = p.HandleResult(c)
+		if err != nil {
+			errorsMap["handle-result"] = err
+		}
+	}
+
+	return errorsMap
+}

--- a/internal/pkg/pluginengine/plugin.go
+++ b/internal/pkg/pluginengine/plugin.go
@@ -1,11 +1,6 @@
 package pluginengine
 
 import (
-	"fmt"
-	"plugin"
-
-	"github.com/spf13/viper"
-
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 )
 
@@ -42,30 +37,4 @@ func Uninstall(tool *configloader.Tool) (bool, error) {
 		return false, err
 	}
 	return p.Uninstall(&tool.Options)
-}
-
-func loadPlugin(tool *configloader.Tool) (DevStreamPlugin, error) {
-	pluginDir := viper.GetString("plugin-dir")
-	if pluginDir == "" {
-		return nil, fmt.Errorf("plugin-dir is \"\"")
-	}
-
-	mod := fmt.Sprintf("%s/%s_%s.so", pluginDir, tool.Name, tool.Version)
-	plug, err := plugin.Open(mod)
-	if err != nil {
-		return nil, err
-	}
-
-	var devStreamPlugin DevStreamPlugin
-	symDevStreamPlugin, err := plug.Lookup("DevStreamPlugin")
-	if err != nil {
-		return nil, err
-	}
-
-	devStreamPlugin, ok := symDevStreamPlugin.(DevStreamPlugin)
-	if !ok {
-		return nil, err
-	}
-
-	return devStreamPlugin, nil
 }

--- a/internal/pkg/pluginmanager/downloader_test.go
+++ b/internal/pkg/pluginmanager/downloader_test.go
@@ -9,16 +9,15 @@ import (
 )
 
 func TestDownload(t *testing.T) {
+	os.Remove(filepath.Join(".", "argocdapp_0.0.1-rc1.so"))
 
-	os.Remove(filepath.Join(".", "argocdapp"))
+	c := NewDownloadClient()
+	err := c.download(".", "argocdapp_0.0.1-rc1.so", "0.0.1-rc1")
+	if err != nil {
+		t.Fatal("downloaded error")
+	}
 
-	//c := NewDownloadClient()
-	//err := c.download(".", "argocdapp_0.0.1-rc1.so", "0.0.1-rc1")
-	//if err != nil {
-	//	t.Fatal("downloaded error")
-	//}
-
-	os.Remove(filepath.Join(".", "argocdapp"))
+	os.Remove(filepath.Join(".", "argocdapp_0.0.1-rc1.so"))
 }
 
 func TestDownloadNotFound(t *testing.T) {

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -18,7 +18,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 	if pluginDir == "" {
 		return fmt.Errorf("plugins directory should not be \"\"")
 	}
-	log.Printf("prepare to use dir < %s > to hold the plugins", pluginDir)
+	log.Printf("Using dir <%s> to store plugins.", pluginDir)
 
 	// download all plugins that don't exist locally
 	dc := NewPbDownloadClient()
@@ -27,15 +27,13 @@ func DownloadPlugins(conf *configloader.Config) error {
 		pluginFileName := configloader.GetPluginFileName(&tool)
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); errors.Is(err, os.ErrNotExist) {
 			// plugin does not exist
-			log.Printf("=== downloading plugin: %s ===", pluginFileName)
 			err := dc.download(pluginDir, pluginFileName, tool.Version)
 			if err != nil {
 				return err
 			}
-			log.Printf("=== plugin: %s has been downloaded ===", pluginFileName)
 			continue
 		}
-		log.Printf("=== plugin: %s exists ===", pluginFileName)
+		log.Printf("Plugin: %s already exists, no need to download.", pluginFileName)
 	}
 
 	return nil

--- a/internal/pkg/pluginmanager/pbdownloader.go
+++ b/internal/pkg/pluginmanager/pbdownloader.go
@@ -44,7 +44,7 @@ func (pd *PbDownloadClient) download(pluginsDir, pluginFilename, version string)
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		log.Printf("[INFO] downloading: [%s]**\n**", pluginFilename)
+		log.Printf("Downloading: [%s] ...", pluginFilename)
 
 		downFile, err := os.Create(filepath.Join(pluginsDir, tmpName))
 		if err != nil {
@@ -58,9 +58,9 @@ func (pd *PbDownloadClient) download(pluginsDir, pluginFilename, version string)
 			log.Print(errSetup)
 			return errSetup
 		}
-		log.Printf("[INFO] [%s] download success.", pluginFilename)
+		log.Printf("[%s] download succeeded.", pluginFilename)
 	} else {
-		log.Printf("[ERROR] [%s] download fail,%s.", pluginFilename, resp.Status)
+		log.Printf("[%s] download failed, %s.", pluginFilename, resp.Status)
 		if err = os.Remove(filepath.Join(pluginsDir, tmpName)); err != nil {
 			return err
 		}

--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -14,9 +14,9 @@ const (
 )
 
 const (
-	ActionInstall   ComponentAction = "install"
-	ActionReinstall ComponentAction = "reinstall"
-	ActionUninstall ComponentAction = "uninstall"
+	ActionInstall   ComponentAction = "Install"
+	ActionReinstall ComponentAction = "Reinstall"
+	ActionUninstall ComponentAction = "Uninstall"
 )
 
 // State is the single component's state.


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.

## Description

Build:
- `make build` will make sure the default plugins directory exists (`.devstream`) and will build the plugins to `.devstream/*.so`
- `make fmt` changed to `go install` (starting in Go 1.17, installing executables with go get is deprecated)

Command/Engine:
- init: the logic isn't changed; apply without init will also work.
- apply: the `applyCMDFunc` is hugely reduced, moving the main logic to a new function `pluginengine.Run`
- a new helper file for the engine module is created to better organize the code structure

Configloader:
- viper initialization is moved out of the `initConfig` function (bug: `dtm` without any subcommand would fail because it tries to load the config file)
- viper UnmarshalKey is moved to `configloader.LoadConf` to reduce duplicated code

State/Backend:
- default state file is changed from `.devstream/devstream.state` to `devstream.state`
- local backend will create a new empty file if it doesn't exist. This solves the minor bug that the first time when dtm is executed, there is no state, hence stateMap reading would cause an error output
- fixing a bug that after installation, the state is still "running" instead of "installed"

Plugins:
- default plugins directory: changed from `.devstream/plugins` to `.devstream`.
- argocd plugin: cascading deletion of an app when the Application CRD is deleted (for easier local testing)

**Note: the changes of state/plugins are due to the fact that if using `-p` to specify another directory for plugins, the state file will still live at `.devstream/devstreamstate` but the `.devstream` folder might not exist since it's not created by the `init`.**

Plan:
- `plan.Execute` now is moved to the plugin engine module, so that there are no circular references (engine uses plan.execute, which uses engine.install). Because of this, `change.Action` is removed; only `change.ActionName` is used.
- a `plan_helper` is created to better organize the code, and the `result` is separated with `plan`

Logging:
- removed "===" prefixes and suffixes (will be further improved by introducing another logging module)
- fixed some grammar errors

Test:
- fixed a commented test

### Related Issues

Closes #64 
Closes #102 
