### PR TITLE
refactor: only check, no download plugins before apply

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -22,7 +22,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 
 	err := pluginengine.Apply(configFile)
 	if err != nil {
-		log.Printf("Apply error: %s. Maybe you forgot to run \"dtm init\" first?", err)
+		log.Printf("Apply error: %s.", err)
 		os.Exit(1)
 	}
 

--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -22,7 +22,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 
 	err := pluginengine.Apply(configFile)
 	if err != nil {
-		log.Printf("Apply error: %s.", err)
+		log.Printf("Apply error: %s. Maybe you forgot to run \"dtm init\" first?", err)
 		os.Exit(1)
 	}
 

--- a/internal/pkg/pluginengine/apply.go
+++ b/internal/pkg/pluginengine/apply.go
@@ -16,6 +16,7 @@ func Apply(fname string) error {
 
 	err := pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {
+		log.Printf("Error checking required plugins. Maybe you forgot to run \"dtm init\" first?")
 		return err
 	}
 

--- a/internal/pkg/pluginengine/apply.go
+++ b/internal/pkg/pluginengine/apply.go
@@ -7,18 +7,17 @@ import (
 	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/planmanager"
+	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
 func Apply(fname string) error {
 	cfg := configloader.LoadConf(fname)
 
-	// TODO(ironcore864): hot fix, so that local test will work. Will fix the logic later.
-	// init before installation
-	// err := pluginmanager.DownloadPlugins(cfg)
-	// if err != nil {
-	// 	return err
-	// }
+	err := pluginmanager.CheckLocalPlugins(cfg)
+	if err != nil {
+		return err
+	}
 
 	// use default local backend for now.
 	b, err := backend.GetBackend("local")

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -70,7 +70,7 @@ func CheckLocalPlugins(conf *configloader.Config) error {
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("plugin %s directory doesn't exist", tool.Name)
+			return fmt.Errorf("plugin %s doesn't exist", tool.Name)
 		}
 	}
 

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -3,10 +3,11 @@ package pluginmanager
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/viper"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 )
@@ -49,6 +50,29 @@ func DownloadPlugins(conf *configloader.Config) error {
 		}
 		if err = dc.download(pluginDir, pluginFileName, tool.Version); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func CheckLocalPlugins(conf *configloader.Config) error {
+	pluginDir := viper.GetString("plugin-dir")
+	if pluginDir == "" {
+		return fmt.Errorf("plugins directory doesn't exist")
+	}
+
+	log.Printf("Using dir <%s> to store plugins.", pluginDir)
+
+	// download all plugins that don't exist locally
+
+	for _, tool := range conf.Tools {
+		pluginFileName := configloader.GetPluginFileName(&tool)
+		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); errors.Is(err, os.ErrNotExist) {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("plugin %s directory doesn't exist", tool.Name)
 		}
 	}
 

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -64,8 +64,6 @@ func CheckLocalPlugins(conf *configloader.Config) error {
 
 	log.Printf("Using dir <%s> to store plugins.", pluginDir)
 
-	// download all plugins that don't exist locally
-
 	for _, tool := range conf.Tools {
 		pluginFileName := configloader.GetPluginFileName(&tool)
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.

## Description

This is a breaking change.

### Related Issues

Closes #102 

### Current Behavior

Apply will init first (which will download plugins if they don't exist).

### New Behavior

Apply WILL NOT init first. Apply only checks if needed plugins exist; if not, an error will be returned instead of downloading the plugins for the user.

### Screenshots

<img width="1134" alt="Screenshot 2022-01-11 at 11 44 38" src="https://user-images.githubusercontent.com/19277614/148877817-cabcc696-b50c-4d5a-93fb-dd3e4b8e1dfc.png">
