### PR TITLE
Feat: Cross-platform Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@
 *.dylib
 
 # build
-dtm
+dtm*
+build/output
+build/working_dir
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-core-only: fmt vet ## Build dtm core only, without plugins, locally.
 
 clean:
 	rm -rf .devstream
-	rm dtm*
+	rm -f dtm*
 	rm -rf build/working_dir
 
 build-release: build-darwin-arm64 build-darwin-amd64 build-linux-amd64 ## Build for all platforms for release.
@@ -41,11 +41,12 @@ build-darwin-amd64: ## Cross-platform build for darwin/amd64.
 
 build-linux-amd64: ## Cross-platform build for linux/amd64
 	echo "Building in ${BUILD_PATH}"
+	mkdir -p .devstream
 	rm -rf ${BUILD_PATH} && mkdir ${BUILD_PATH}
-	# docker buildx build --platform linux/amd64,linux/arm64 --push -t ironcore864/dtm-builder:v0.0.1 -f build/package/Dockerfile .
+	docker buildx build --platform linux/amd64 --load -t mericodev/stream-builder:v0.0.1 -f build/package/Dockerfile .
 	cp -r go.mod go.sum cmd internal build/package/build_linux_amd64.sh ${BUILD_PATH}/
 	chmod +x ${BUILD_PATH}/build_linux_amd64.sh
-	docker run --rm --platform linux/amd64 -v ${BUILD_PATH}:/devstream ironcore864/dtm-builder:v0.0.1
+	docker run --rm --platform linux/amd64 -v ${BUILD_PATH}:/devstream mericodev/stream-builder:v0.0.1
 	mv ${BUILD_PATH}/output/*.so .devstream/
 	mv ${BUILD_PATH}/output/dtm* .
 	rm -rf ${BUILD_PATH}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+MKFILE_PATH=$(abspath $(lastword $(MAKEFILE_LIST)))
+BUILD_PATH=$(patsubst %/,%,$(dir $(MKFILE_PATH)))/build/working_dir
+
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 build: fmt vet ## Build dtm & plugins locally.
 	go mod tidy
@@ -9,9 +12,43 @@ build: fmt vet ## Build dtm & plugins locally.
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp_0.0.1.so ./cmd/argocdapp/
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
-build-core: fmt vet ## Build dtm core only, locally.
+build-core-only: fmt vet ## Build dtm core only, locally; for faster local testing without rebuilding all plugins.
 	go mod tidy
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
+
+clean:
+	rm -rf .devstream
+	rm dtm*
+	rm -rf build/working_dir
+
+build-release: build-darwin-arm64 build-darwin-amd64 build-linux-amd64 ## Build for all platforms for release.
+
+build-darwin-arm64: ## Build for darwin/arm64 for release.
+	go mod tidy
+	mkdir -p .devstream
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-darwin-arm64_0.0.1.so ./cmd/githubactions/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd-darwin-arm64_0.0.1.so ./cmd/argocd/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp-darwin-arm64_0.0.1.so ./cmd/argocdapp/
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -gcflags="all=-N -l" -o dtm-darwin-arm64 ./cmd/devstream/
+
+build-darwin-amd64: ## Cross-platform build for darwin/amd64.
+	go mod tidy
+	mkdir -p .devstream
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-darwin-amd64_0.0.1.so ./cmd/githubactions/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd-darwin-amd64_0.0.1.so ./cmd/argocd/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp-darwin-amd64_0.0.1.so ./cmd/argocdapp/
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -gcflags="all=-N -l" -o dtm-darwin-amd64 ./cmd/devstream/
+
+build-linux-amd64: ## Cross-platform build for linux/amd64
+	echo "Building in ${BUILD_PATH}"
+	rm -rf ${BUILD_PATH} && mkdir ${BUILD_PATH}
+	# docker buildx build --platform linux/amd64,linux/arm64 --push -t ironcore864/dtm-builder:v0.0.1 -f build/package/Dockerfile .
+	cp -r go.mod go.sum cmd internal build/package/build_linux_amd64.sh ${BUILD_PATH}/
+	chmod +x ${BUILD_PATH}/build_linux_amd64.sh
+	docker run --rm --platform linux/amd64 -v ${BUILD_PATH}:/devstream ironcore864/dtm-builder:v0.0.1
+	mv ${BUILD_PATH}/output/*.so .devstream/
+	mv ${BUILD_PATH}/output/dtm* .
+	rm -rf ${BUILD_PATH}
 
 fmt: ## Run 'go fmt' & goimports against code.
 	go install golang.org/x/tools/cmd/goimports@latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MKFILE_PATH=$(abspath $(lastword $(MAKEFILE_LIST)))
 BUILD_PATH=$(patsubst %/,%,$(dir $(MKFILE_PATH)))/build/working_dir
 
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 build: fmt vet ## Build dtm & plugins locally.
 	go mod tidy
@@ -12,7 +12,7 @@ build: fmt vet ## Build dtm & plugins locally.
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp_0.0.1.so ./cmd/argocdapp/
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 
-build-core-only: fmt vet ## Build dtm core only, locally; for faster local testing without rebuilding all plugins.
+build-core-only: fmt vet ## Build dtm core only, without plugins, locally.
 	go mod tidy
 	go build -trimpath -gcflags="all=-N -l" -o dtm ./cmd/devstream/
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,28 @@ See [docs/architecture.md](./docs/architecture.md).
 
 ## Build
 
+```makefile
+$ make help
+
+Usage:
+  make <target>
+  help                Display this help.
+  build               Build dtm & plugins locally.
+  build-core-only     Build dtm core only, without plugins, locally.
+  build-release       Build for all platforms for release.
+  build-darwin-arm64  Build for darwin/arm64 for release.
+  build-darwin-amd64  Cross-platform build for darwin/amd64.
+  build-linux-amd64   Cross-platform build for linux/amd64
+  fmt                 Run 'go fmt' & goimports against code.
+  vet                 Run go vet against code.
+```
+
+## Test
+
+Unit/functional test:
+
 ```bash
-# build dtm & plugins
-make build
-# build dtm only
-make build-core
+go test ./...
 ```
 
 ## Configuration
@@ -70,15 +87,23 @@ See [examples/config.yaml](./examples/config.yaml).
 
 ## Run
 
-The CLI tool is named `dtm`, which is an acronym of **d**evs**t**rea**m** or *devops toolchain manager*:
+To install/reinstall/update, run:
 
 ```bash
-./dtm install -f examples/config.yaml
+./dtm apply -f examples/config.yaml
+```
+
+To delete, run:
+
+```bash
+./dtm delete -f examples/config.yaml
 ```
 
 ## Why `dtm`?
 
-Inspired by [`git`](https://github.com/git/git#readme), the name is (depending on your mood):
+Q: The CLI tool is named `dtm`, while the tool itself is called DevStream. What the heck?! Where is the consistency?
+
+A: Inspired by [`git`](https://github.com/git/git#readme), the name is (depending on your mood):
 
 - a symmetric, scientific acronym of **d**evs**t**rea**m**.
 - "devops toolchain manager": you're in a good mood, and it actually works for you.

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.17 as builder
+
+WORKDIR /devstream
+
+# cache deps before building so that source changes don't invalidate our downloaded layer
+COPY go.mod go.sum /devstream/
+
+RUN go mod download
+
+CMD ["./build_linux_amd64.sh"]

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -7,4 +7,5 @@ COPY go.mod go.sum /devstream/
 
 RUN go mod download
 
+# the script will be copied to a mounted volume before docker run
 CMD ["./build_linux_amd64.sh"]

--- a/build/package/build_linux_amd64.sh
+++ b/build/package/build_linux_amd64.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+export GOOS=linux
+export GOARCH=amd64
+go build -trimpath -gcflags="all=-N -l" -o output/dtm-${GOOS}-${GOARCH} ./cmd/devstream/
+go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/githubactions-${GOOS}-${GOARCH}_0.0.1.so ./cmd/githubactions/
+go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/argocd-${GOOS}-${GOARCH}_0.0.1.so ./cmd/argocd/
+go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/argocdapp-${GOOS}-${GOARCH}_0.0.1.so ./cmd/argocdapp/

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -3,10 +3,11 @@ package pluginmanager
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/viper"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 )


### PR DESCRIPTION
# Summary

## Description

This PR supports building dtm and its plugins in a cross-platform manner. 

Src platform: darwin/arm64 (M1 Mac, aarch64)

| Destination platforms | Command to Build          | Method to Build | Why                                                                                          |
|-----------------------|---------------------------|-----------------|----------------------------------------------------------------------------------------------|
| darwin/arm64          | `make build-darwin-arm64` | local           | faster                                                                                       |
| darwin/amd64          | `make build-darwin-amd64` | local           | faster                                                                                       |
| linux/amd64           | `make build-linux-amd64`  | container       | plugin cross-platform build in container is a must https://github.com/golang/go/issues/22462 |

Other changes:

- updated readme and makefile comments
- created a `build` folder according to our [project layout doc](https://github.com/merico-dev/stream/blob/main/docs/project_layout.md#build)
- `make build-release` that builds for all platforms, useful when releasing a new version for all platforms.
- 

## Related Issues

Resolves #18 
Resolves #21 

## Screenshot

Test:

<img width="1434" alt="Screenshot 2022-01-11 at 12 17 18" src="https://user-images.githubusercontent.com/19277614/148880311-54e8936c-90e8-4312-9905-156ed368704d.png">
