### PR TITLE
feat: plugin supports multiple instances

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -21,6 +21,17 @@ tools:
         coverage:
           enable: False
           profile: "-race -coverprofile=coverage.out -covermode=atomic"
+- name: dtm-test1-ci
+  plugin:
+    kind: githubactions
+    version: 0.0.1
+  options:
+    owner: ironcore864
+    repo: dtm-test1
+    language:
+      name: go
+      version: "1.17"
+    branch: main
 - name: argocd-dev
   plugin:
     kind: argocd
@@ -48,4 +59,19 @@ tools:
     source:
       valuefile: values.yaml
       path: charts/go-hello-http
+      repoURL: https://github.com/ironcore864/openstream-gitops-test.git
+- name: argocdapp-demo-app
+  plugin:
+    kind: argocdapp
+    version: 0.0.1
+  options:
+    app:
+      name: demo-app
+      namespace: argocd
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: charts/demo-app
       repoURL: https://github.com/ironcore864/openstream-gitops-test.git

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/argoproj/gitops-engine v0.5.2
 	github.com/cheggaaa/pb v1.0.29
 	github.com/go-resty/resty/v2 v2.7.0
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v40 v40.0.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/mittwald/go-helm-client v0.8.4
@@ -76,7 +77,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github/v38 v38.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -2,9 +2,10 @@ package configloader
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 
-	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // Config is the struct for loading DevStream configuration YAML files.
@@ -39,27 +40,21 @@ func (t *Tool) DeepCopy() *Tool {
 
 // LoadConf reads an input file as a Config struct.
 func LoadConf(fname string) *Config {
-	if fname != "" {
-		viper.SetConfigFile(fname)
-	} else {
-		viper.AddConfigPath(".")
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("config")
-	}
-
-	if err := viper.ReadInConfig(); err != nil {
+	fileBytes, err := ioutil.ReadFile(fname)
+	if err != nil {
 		log.Print(err)
 		log.Print("Perhaps you forgot to specify the path of the config file by using the \"-f\" parameter?")
 		log.Fatal("See more help by running \"dtm help\"")
 	}
 
-	var tools = make([]Tool, 0)
+	config := Config{}
 
-	if err := viper.UnmarshalKey("tools", &tools); err != nil {
+	err = yaml.Unmarshal(fileBytes, &config)
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	return &Config{Tools: tools}
+	return &config
 }
 
 // GetPluginFileName creates the file name based on the tool's name and version

--- a/internal/pkg/planmanager/plan_apply.go
+++ b/internal/pkg/planmanager/plan_apply.go
@@ -34,6 +34,7 @@ func NewPlan(smgr statemanager.Manager, cfg *configloader.Config) *Plan {
 			statesMap.Store(k, v)
 		}
 		smgr.SetStatesMap(statesMap)
+
 		log.Printf("Succeeded initializing StatesMap.")
 	} else {
 		log.Printf("Failed to initialize StatesMap. Error: (%s). Try to initialize the StatesMap.", err)
@@ -46,6 +47,5 @@ func NewPlan(smgr statemanager.Manager, cfg *configloader.Config) *Plan {
 	tmpStates := smgr.GetStatesMap().DeepCopy()
 	plan.generatePlanAccordingToConfig(tmpStates, cfg)
 	plan.removeNoLongerNeededToolsFromPlan(tmpStates)
-
 	return plan
 }

--- a/internal/pkg/planmanager/plan_helper.go
+++ b/internal/pkg/planmanager/plan_helper.go
@@ -2,14 +2,15 @@ package planmanager
 
 import (
 	"log"
-	"reflect"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
 func drifted(t *configloader.Tool, s *statemanager.State) bool {
-	return !reflect.DeepEqual(t.Options, s.Metadata) || !reflect.DeepEqual(t.Plugin, s.Plugin)
+	return !cmp.Equal(t.Options, s.Metadata) || !cmp.Equal(t.Plugin, s.Plugin)
 }
 
 // generatePlanAccordingToConfig is to filter all the Tools in cfg that need some actions
@@ -33,7 +34,7 @@ func (p *Plan) generatePlanAccordingToConfig(statesMap *statemanager.StatesMap, 
 			log.Printf("Change added: %s -> %s", tool.Name, statemanager.ActionReinstall)
 		}
 
-		statesMap.Delete(tool.Name)
+		statesMap.Delete(getStateKeyFromTool(&tool))
 	}
 }
 

--- a/internal/pkg/plugin/argocd/argocd.go
+++ b/internal/pkg/plugin/argocd/argocd.go
@@ -65,7 +65,8 @@ func (a *ArgoCD) installOrUpgradeHelmChart() error {
 		CreateNamespace: a.param.Chart.CreateNamespace,
 		UpgradeCRDs:     true,
 		Wait:            true,
-		Timeout:         3 * time.Minute,
+		// increasing the timeout because it seems this function can't do a "helm upgrade --install"
+		Timeout: 5 * time.Minute,
 	}
 
 	_, err := (*a.client).InstallOrUpgradeChart(context.Background(), &chartSpec)

--- a/internal/pkg/plugin/argocdapp/install.go
+++ b/internal/pkg/plugin/argocdapp/install.go
@@ -1,6 +1,8 @@
 package argocdapp
 
 import (
+	"os"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -13,13 +15,15 @@ func Install(options *map[string]interface{}) (bool, error) {
 	}
 
 	file := defaultYamlPath
-	err = writeContentToTmpFile(file, appTemplate, &param)
-	if err != nil {
+	if err = writeContentToTmpFile(file, appTemplate, &param); err != nil {
 		return false, err
 	}
 
-	err = kubectlAction(ActionApply, file)
-	if err != nil {
+	if err = kubectlAction(ActionApply, file); err != nil {
+		return false, err
+	}
+
+	if err = os.Remove(file); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/argocdapp/uninstall.go
+++ b/internal/pkg/plugin/argocdapp/uninstall.go
@@ -15,8 +15,7 @@ func Uninstall(options *map[string]interface{}) (bool, error) {
 	}
 
 	file := defaultYamlPath
-	err = kubectlAction(ActionDelete, file)
-	if err != nil {
+	if err = kubectlAction(ActionDelete, file); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/argocdapp/uninstall.go
+++ b/internal/pkg/plugin/argocdapp/uninstall.go
@@ -15,6 +15,10 @@ func Uninstall(options *map[string]interface{}) (bool, error) {
 	}
 
 	file := defaultYamlPath
+	if err = writeContentToTmpFile(file, appTemplate, &param); err != nil {
+		return false, err
+	}
+
 	if err = kubectlAction(ActionDelete, file); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.

## Description

- `viper` is changed to `yaml.v3` for config loading. This is because `viper` loads the object into `map[interface{}]interface{}` instead of `map[string]interface{}` (the latter of which is the state).
- `reflect.DeepEqual` is changed to `cmp.Equal`, which is intended to be a more powerful and safer alternative for comparing whether two values are semantically equal.
- bug fix: fix a bug that the argocdapp plugin only deletes the temp file in Uninstall but not in Install
- argocd app: timeout increased to 5 min. This is because, it seems that the go-helm-client doesn't do the upgrade in a `helm upgrade --install` fashion and will generate an error if the first install fails.
- some minor refactor to make the Go code more idiomatic.