### PR TITLE
feat: apply/delete asks for confirmatin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,22 @@ To install/reinstall/update, run:
 ./dtm apply -f examples/config.yaml
 ```
 
+The command above will ask you for confirmation before actually executing the changes. To apply without confirmation (like `apt-get -y update`), run:
+
+```bash
+./dtm -y apply -f examples/config.yaml
+```
+
 To delete, run:
 
 ```bash
 ./dtm delete -f examples/config.yaml
+```
+
+Similarly, to delete without confirmation:
+
+```bash
+./dtm -y delete -f examples/config.yaml
 ```
 
 To verify, run:

--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -20,7 +20,7 @@ DevStream will generate and execute a new plan based on the config file and the 
 func applyCMDFunc(cmd *cobra.Command, args []string) {
 	log.Println("Apply started.")
 
-	if err := pluginengine.Apply(configFile); err != nil {
+	if err := pluginengine.Apply(configFile, continueDirectly); err != nil {
 		log.Printf("Apply error: %s.", err)
 		os.Exit(1)
 	}

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -20,7 +20,7 @@ DevStream will delete everything defined in the config file, regardless of the s
 func deleteCMDFunc(cmd *cobra.Command, args []string) {
 	log.Println("Delete started.")
 
-	if err := pluginengine.Delete(configFile); err != nil {
+	if err := pluginengine.Delete(configFile, continueDirectly); err != nil {
 		log.Printf("Delete error: %s.", err)
 		os.Exit(1)
 	}

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	configFile string
-	pluginDir  string
+	configFile       string
+	pluginDir        string
+	continueDirectly bool
 
 	rootCMD = &cobra.Command{
 		Use:   "dtm",
@@ -26,6 +27,7 @@ func init() {
 
 	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
 	rootCMD.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "p", pluginengine.DefaultPluginDir, "plugins directory")
+	rootCMD.PersistentFlags().BoolVarP(&continueDirectly, "yes", "y", false, "apply/delete directly without confirmation")
 
 	rootCMD.AddCommand(versionCMD)
 	rootCMD.AddCommand(initCMD)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.7.2

--- a/go.sum
+++ b/go.sum
@@ -1179,6 +1179,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8 h1:RB0v+/pc8oMzPsN97aZYEwNuJ6ouRJ2uhjxemJ9zvrY=
+github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8/go.mod h1:IlWNj9v/13q7xFbaK4mbyzMNwrZLaWSHx/aibKIZuIg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/pkg/pluginengine/apply.go
+++ b/internal/pkg/pluginengine/apply.go
@@ -3,6 +3,7 @@ package pluginengine
 import (
 	"errors"
 	"log"
+	"os"
 
 	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
@@ -11,7 +12,7 @@ import (
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
-func Apply(fname string) error {
+func Apply(fname string, continueDirectly bool) error {
 	cfg := configloader.LoadConf(fname)
 
 	err := pluginmanager.CheckLocalPlugins(cfg)
@@ -32,6 +33,13 @@ func Apply(fname string) error {
 	if len(p.Changes) == 0 {
 		log.Println("No changes done since last apply. There is nothing to do.")
 		return nil
+	}
+
+	if !continueDirectly {
+		userInput := readUserInput()
+		if userInput == "n" {
+			os.Exit(0)
+		}
 	}
 
 	errsMap := execute(p)

--- a/internal/pkg/pluginengine/delete.go
+++ b/internal/pkg/pluginengine/delete.go
@@ -3,6 +3,7 @@ package pluginengine
 import (
 	"errors"
 	"log"
+	"os"
 
 	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
@@ -11,7 +12,7 @@ import (
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
-func Delete(fname string) error {
+func Delete(fname string, continueDirectly bool) error {
 	cfg := configloader.LoadConf(fname)
 
 	err := pluginmanager.CheckLocalPlugins(cfg)
@@ -31,6 +32,13 @@ func Delete(fname string) error {
 	if len(p.Changes) == 0 {
 		log.Println("Nothing needs to be deleted. There is nothing to do.")
 		return nil
+	}
+
+	if !continueDirectly {
+		userInput := readUserInput()
+		if userInput == "n" {
+			os.Exit(0)
+		}
 	}
 
 	errsMap := execute(p)

--- a/internal/pkg/pluginengine/helper.go
+++ b/internal/pkg/pluginengine/helper.go
@@ -3,8 +3,11 @@ package pluginengine
 import (
 	"fmt"
 	"log"
+	"os"
 	"plugin"
 	"time"
+
+	"github.com/tcnksm/go-input"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/planmanager"
@@ -71,4 +74,28 @@ func execute(p *planmanager.Plan) map[string]error {
 	}
 
 	return errorsMap
+}
+
+func readUserInput() string {
+	ui := &input.UI{
+		Writer: os.Stdout,
+		Reader: os.Stdin,
+	}
+
+	query := "Continue? [y/n]"
+	userInput, err := ui.Ask(query, &input.Options{
+		Required: true,
+		Default:  "n",
+		Loop:     true,
+		ValidateFunc: func(s string) error {
+			if s != "y" && s != "n" {
+				return fmt.Errorf("input must be y or n")
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	return userInput
 }


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.
- [x] Documentation (new or existing) is updated.

## Description

- `dtm apply` and `dtm delete` will ask the user's input to decide if the apply/delete should continue (by default, no)
- `dtm -y apply` and `dtm -y delete` bypass the confirmation (just as `apt -y update` does)
- introduced a new third-party package that is `tcnksm/go-input` for easier handling user input
- documentation is updated as well

Closes #143 