### PR TITLE
Feat rename plugins for darwin arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ help: ## Display this help.
 build: fmt vet ## Build dtm & plugins locally.
 	go mod tidy
 	mkdir -p .devstream
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions_${VERSION}.so ./cmd/githubactions/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/trello-github-integ_${VERSION}.so ./cmd/trellogithub/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd_${VERSION}.so ./cmd/argocd/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp_${VERSION}.so ./cmd/argocdapp/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/kube-prometheus_${VERSION}.so ./cmd/kubeprometheus/
-	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/github-repo-scaffolding-golang_${VERSION}.so ./cmd/reposcaffolding/github/golang/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-darwin-arm64_${VERSION}.so ./cmd/githubactions/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/trello-github-integ-darwin-arm64_${VERSION}.so ./cmd/trellogithub/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd-darwin-arm64_${VERSION}.so ./cmd/argocd/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp-darwin-arm64_${VERSION}.so ./cmd/argocdapp/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/kube-prometheus-darwin-arm64_${VERSION}.so ./cmd/kubeprometheus/
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/github-repo-scaffolding-golang-darwin-arm64_${VERSION}.so ./cmd/reposcaffolding/github/golang/
 	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/internal/pkg/version.VERSION=${VERSION}" -o dtm ./cmd/devstream/
 
 build-core: fmt vet ## Build dtm core only, without plugins, locally.

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -3,10 +3,16 @@ package configloader
 import (
 	"fmt"
 	"io/ioutil"
+	"runtime"
 
 	"github.com/merico-dev/stream/internal/pkg/log"
 
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	GOOS   string = runtime.GOOS
+	GOARCH string = runtime.GOARCH
 )
 
 // Config is the struct for loading DevStream configuration YAML files.
@@ -75,5 +81,5 @@ func LoadConf(fname string) *Config {
 // GetPluginFileName creates the file name based on the tool's name and version
 // If the plugin {githubactions 0.0.1}, the generated name will be "githubactions_0.0.1.so"
 func GetPluginFileName(t *Tool) string {
-	return fmt.Sprintf("%s_%s.so", t.Plugin.Kind, t.Plugin.Version)
+	return fmt.Sprintf("%s-%s-%s_%s.so", t.Plugin.Kind, GOOS, GOARCH, t.Plugin.Version)
 }


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.

## Description

Plugin name is changed from `PLUGIN-NAME_VERSION.so` to `PLUGIN-NAME-GOOS-GOARCH_VERSION.so`.
