### PR TITLE
Feat: delete namespace when uninstall argocd & kube-prometheus

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -57,7 +57,6 @@ tools:
       chart_name: argo/argo-cd
       release_name: argocd
       namespace: argocd
-      create_namespace: True
       wait: true
       timeout: 5m
       upgradeCRDs: true
@@ -88,7 +87,6 @@ tools:
       chart_name: prometheus-community/kube-prometheus-stack
       release_name: dev
       namespace: monitoring
-      create_namespace: True
       wait: true
       timeout: 5m
       upgradeCRDs: true

--- a/internal/pkg/plugin/argocd/reinstall.go
+++ b/internal/pkg/plugin/argocd/reinstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/pkg/util/helm"
+	"github.com/merico-dev/stream/pkg/util/k8s"
 )
 
 func Reinstall(options *map[string]interface{}) (bool, error) {
@@ -32,6 +33,17 @@ func Reinstall(options *map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
+	// delete the namespace
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return false, err
+	}
+	if err = kubeClient.DeleteNamespace(param.Chart.Namespace); err != nil {
+		log.Errorf("Failed to delete the %s namespace: %s", param.Chart.Namespace, err)
+		return false, err
+	}
+
+	// install
 	log.Info("Installing or updating argocd helm chart ...")
 	if err = h.InstallOrUpgradeChart(); err != nil {
 		return false, err

--- a/internal/pkg/plugin/argocd/uninstall.go
+++ b/internal/pkg/plugin/argocd/uninstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/pkg/util/helm"
+	"github.com/merico-dev/stream/pkg/util/k8s"
 )
 
 func Uninstall(options *map[string]interface{}) (bool, error) {
@@ -29,6 +30,16 @@ func Uninstall(options *map[string]interface{}) (bool, error) {
 
 	log.Info("uninstalling argocd helm chart")
 	if err = h.UninstallHelmChartRelease(); err != nil {
+		return false, err
+	}
+
+	// delete the namespace
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return false, err
+	}
+	if err = kubeClient.DeleteNamespace(param.Chart.Namespace); err != nil {
+		log.Errorf("Failed to delete the %s namespace: %s", param.Chart.Namespace, err)
 		return false, err
 	}
 

--- a/internal/pkg/plugin/kubeprometheus/reinstall.go
+++ b/internal/pkg/plugin/kubeprometheus/reinstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/pkg/util/helm"
+	"github.com/merico-dev/stream/pkg/util/k8s"
 )
 
 // Reinstall re-installs kube-prometheus with provided options.
@@ -33,6 +34,17 @@ func Reinstall(options *map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
+	// delete the namespace
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return false, err
+	}
+	if err = kubeClient.DeleteNamespace(param.Chart.Namespace); err != nil {
+		log.Errorf("Failed to delete the %s namespace: %s", param.Chart.Namespace, err)
+		return false, err
+	}
+
+	// install
 	log.Info("Installing or updating kube-prometheus-stack helm chart ...")
 	if err = h.InstallOrUpgradeChart(); err != nil {
 		return false, err

--- a/internal/pkg/plugin/kubeprometheus/uninstall.go
+++ b/internal/pkg/plugin/kubeprometheus/uninstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/pkg/util/helm"
+	"github.com/merico-dev/stream/pkg/util/k8s"
 )
 
 // Uninstall uninstalls kube-prometheus with provided options.
@@ -30,6 +31,16 @@ func Uninstall(options *map[string]interface{}) (bool, error) {
 
 	log.Info("Uninstalling kube-prometheus-stack helm chart ...")
 	if err = h.UninstallHelmChartRelease(); err != nil {
+		return false, err
+	}
+
+	// delete the namespace
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return false, err
+	}
+	if err = kubeClient.DeleteNamespace(param.Chart.Namespace); err != nil {
+		log.Errorf("Failed to delete the %s namespace: %s", param.Chart.Namespace, err)
 		return false, err
 	}
 

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -49,12 +49,13 @@ func NewHelm(param *HelmParam) (*Helm, error) {
 	}
 
 	chartSpec := &helmclient.ChartSpec{
-		ReleaseName:      param.Chart.ReleaseName,
-		ChartName:        param.Chart.ChartName,
-		Namespace:        param.Chart.Namespace,
-		ValuesYaml:       "",
-		Version:          param.Chart.Version,
-		CreateNamespace:  param.Chart.CreateNamespace,
+		ReleaseName: param.Chart.ReleaseName,
+		ChartName:   param.Chart.ChartName,
+		Namespace:   param.Chart.Namespace,
+		ValuesYaml:  "",
+		Version:     param.Chart.Version,
+		// we need to create the namespace if it does not exist
+		CreateNamespace:  true,
 		DisableHooks:     false,
 		Replace:          true,
 		Wait:             param.Chart.Wait,

--- a/pkg/util/k8s/github_test.go
+++ b/pkg/util/k8s/github_test.go
@@ -1,0 +1,17 @@
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	//. "github.com/onsi/gomega"
+	//"github.com/merico-dev/stream/pkg/util/k8s"
+)
+
+var _ = Describe("K8S", func() {
+	Context("Namespace", func() {
+		// TODO(daniel-hutao): the code below is only used local now for the k8s test env not exist at GitHub.
+		//c, err := k8s.NewClient()
+		//Expect(err).NotTo(HaveOccurred())
+		//err = c.DeleteNamespace("monitoring")
+		//Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1,14 +1,10 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
@@ -46,64 +42,4 @@ func NewClient() (*Client, error) {
 		Clientset: clientset,
 		Argocd:    argocdClientset,
 	}, nil
-}
-
-func (c *Client) ListDeployments(namespace string) ([]appsv1.Deployment, error) {
-	dpList, err := c.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return dpList.Items, nil
-}
-
-func (c *Client) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
-	return c.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
-func (c *Client) IsDeploymentReady(deployment *appsv1.Deployment) bool {
-	return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
-}
-
-func (c *Client) ListDaemonsets(namespace string) ([]appsv1.DaemonSet, error) {
-	dsList, err := c.AppsV1().DaemonSets(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return dsList.Items, nil
-}
-
-func (c *Client) GetDaemonset(namespace, name string) (*appsv1.DaemonSet, error) {
-	return c.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
-func (c *Client) IsDaemonsetReady(daemonset *appsv1.DaemonSet) bool {
-	return daemonset.Status.NumberReady == daemonset.Status.DesiredNumberScheduled
-}
-
-func (c *Client) ListStatefulsets(namespace string) ([]appsv1.StatefulSet, error) {
-	ssList, err := c.AppsV1().StatefulSets(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return ssList.Items, nil
-}
-
-func (c *Client) GetStatefulset(namespace, name string) (*appsv1.StatefulSet, error) {
-	return c.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
-func (c *Client) IsStatefulsetReady(statefulset *appsv1.StatefulSet) bool {
-	return statefulset.Status.ReadyReplicas == *statefulset.Spec.Replicas
-}
-
-func (c *Client) ListServices(namespace string) ([]corev1.Service, error) {
-	services, err := c.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return services.Items, nil
-}
-
-func (c *Client) GetService(namespace, name string) (*corev1.Service, error) {
-	return c.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/pkg/util/k8s/k8s_suite_test.go
+++ b/pkg/util/k8s/k8s_suite_test.go
@@ -1,0 +1,13 @@
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlanmanager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8S Suite")
+}

--- a/pkg/util/k8s/static.go
+++ b/pkg/util/k8s/static.go
@@ -1,0 +1,28 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *Client) ListServices(namespace string) ([]corev1.Service, error) {
+	services, err := c.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return services.Items, nil
+}
+
+func (c *Client) GetService(namespace, name string) (*corev1.Service, error) {
+	return c.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteNamespace(namespace string) error {
+	if namespace == "default" || namespace == "kube-system" {
+		return fmt.Errorf("you can't delete the default or kube-system namespace")
+	}
+	return c.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+}

--- a/pkg/util/k8s/workload.go
+++ b/pkg/util/k8s/workload.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *Client) ListDeployments(namespace string) ([]appsv1.Deployment, error) {
+	dpList, err := c.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return dpList.Items, nil
+}
+
+func (c *Client) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
+	return c.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c *Client) IsDeploymentReady(deployment *appsv1.Deployment) bool {
+	return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
+}
+
+func (c *Client) ListDaemonsets(namespace string) ([]appsv1.DaemonSet, error) {
+	dsList, err := c.AppsV1().DaemonSets(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return dsList.Items, nil
+}
+
+func (c *Client) GetDaemonset(namespace, name string) (*appsv1.DaemonSet, error) {
+	return c.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c *Client) IsDaemonsetReady(daemonset *appsv1.DaemonSet) bool {
+	return daemonset.Status.NumberReady == daemonset.Status.DesiredNumberScheduled
+}
+
+func (c *Client) ListStatefulsets(namespace string) ([]appsv1.StatefulSet, error) {
+	ssList, err := c.AppsV1().StatefulSets(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ssList.Items, nil
+}
+
+func (c *Client) GetStatefulset(namespace, name string) (*appsv1.StatefulSet, error) {
+	return c.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c *Client) IsStatefulsetReady(statefulset *appsv1.StatefulSet) bool {
+	return statefulset.Status.ReadyReplicas == *statefulset.Spec.Replicas
+}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Feat: delete namespace when uninstall argocd & kube-prometheus

## Key Points

- [x] Deleting the "create_namespace" param at config.yaml, set create_namespace default to true at util/helm.
- [x] Adding DeleteNamespace() at the util/k8s.
- [x] Split k8s.go up into some smaller files.
- [x] Deleting namespace when Uninstall() in ArgoCD & kibe-prometheus plugins 

/cc @IronCore864 @lfbdev Please take a review at this pr tomorrow.
