### PR TITLE
Fix: dtm version should only return version number without extra logging

### DIFF
--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -75,10 +75,10 @@ func initConfig() {
 func initLog() {
 	if isDebug {
 		logrus.SetLevel(logrus.DebugLevel)
+		log.Info("Log level is: ", logrus.GetLevel())
 	} else {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
-	log.Info("Log level is: ", logrus.GetLevel())
 }
 
 func main() {


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>


# Summary

Fix: dtm version should only return version number without extra logging

### Related Issues

fix #187 

### Screenshots

![image](https://user-images.githubusercontent.com/18692628/154002286-bbae9e2d-07f6-497a-9f66-fa3be2abf44d.png)