### PR TITLE
bug: devlake read result type map[string]bool V.S. map[string]interface{}{

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,6 +167,7 @@ require (
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	google.golang.org/grpc v1.38.0 // indirect

--- a/internal/pkg/plugin/devlake/devlake.go
+++ b/internal/pkg/plugin/devlake/devlake.go
@@ -80,27 +80,28 @@ func readDeploymentsAndServicesAndBuildState() (map[string]interface{}, error) {
 
 	res := make(map[string]interface{})
 
-	res["deployments"] = make(map[string]bool)
-	res["services"] = make(map[string]bool)
+	res["deployments"] = make(map[string]interface{})
+	res["services"] = make(map[string]interface{})
 
 	// check if all deployments are ready
 	for _, d := range devLakeDeployments {
 		// deployment
 		dp, err := kubeClient.GetDeployment(namespace, d)
 		if err == nil && kubeClient.IsDeploymentReady(dp) {
-			res["deployments"].(map[string]bool)[d] = true
+			res["deployments"].(map[string]interface{})[d] = true
 		} else {
-			res["deployments"].(map[string]bool)[d] = true
+			res["deployments"].(map[string]interface{})[d] = true
 		}
 
 		// services
 		_, err = kubeClient.GetService(namespace, d)
 		if err == nil {
-			res["services"].(map[string]bool)[d] = true
+			res["services"].(map[string]interface{})[d] = true
 		} else {
-			res["services"].(map[string]bool)[d] = false
+			res["services"].(map[string]interface{})[d] = false
 		}
 	}
 
+	log.Debugf("Resource read returns: %v.", res)
 	return res, nil
 }

--- a/internal/pkg/plugin/devlake/devlake.go
+++ b/internal/pkg/plugin/devlake/devlake.go
@@ -23,11 +23,11 @@ var devLakeDeployments = [4]string{
 func buildState(p Param) map[string]interface{} {
 	res := make(map[string]interface{})
 
-	res["deployments"] = make(map[string]bool)
-	res["services"] = make(map[string]bool)
+	res["deployments"] = make(map[string]interface{})
+	res["services"] = make(map[string]interface{})
 	for _, d := range devLakeDeployments {
-		res["deployments"].(map[string]bool)[d] = true
-		res["services"].(map[string]bool)[d] = true
+		res["deployments"].(map[string]interface{})[d] = true
+		res["services"].(map[string]interface{})[d] = true
 	}
 
 	return res

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -2,6 +2,7 @@ package pluginengine
 
 import (
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/log"
@@ -28,6 +29,15 @@ func generateAction(tool *configloader.Tool, action statemanager.ComponentAction
 }
 
 func drifted(a, b map[string]interface{}) bool {
+	log.Debugf("a: %v.", a)
+	log.Debugf("b: %v.", b)
+
+	// nil vs empty map
+	if cmp.Equal(a, b, cmpopts.EquateEmpty()) {
+		return false
+	}
+
+	log.Debug(cmp.Diff(a, b))
 	return !cmp.Equal(a, b)
 }
 


### PR DESCRIPTION
# Summary

## Description

DevLake plugin read returns:

```
"deployments": map[string]bool{"config-ui": true, "devlake": true, "grafana": true, "mysql": true}
```

Updated to:

```
 	"deployments": map[string]interface{}{
 		"config-ui": bool(true),
 		"devlake":   bool(true),
 		"grafana":   bool(true),
 		"mysql":     bool(true),
 	},
```

Also add a little logging for easier debugging.