### PR TITLE
Bugfix: trello state bugfix

### DIFF
--- a/docs/plugins/trello-github-integ_plugin.md
+++ b/docs/plugins/trello-github-integ_plugin.md
@@ -11,6 +11,9 @@ _This plugin depends on the following two environment variables:_
 
 Set the values accordingly before using this plugin.
 
+## 3 Tips:
+_Trello board description managed by DevStream, don't modify it_
+
 To create a Trello API key and token, see [here](https://docs.servicenow.com/bundle/quebec-it-asset-management/page/product/software-asset-management2/task/generate-trello-apikey-token.html).
 
 ```yaml
@@ -32,6 +35,7 @@ tools:
     # integration tool name
     api:
       name: trello
+      kanban: kanban-name
     # main branch of the repo (to which branch the plugin will submit the workflows)
     branch: master
 ```

--- a/docs/plugins/trello-github-integ_plugin.md
+++ b/docs/plugins/trello-github-integ_plugin.md
@@ -12,7 +12,7 @@ _This plugin depends on the following two environment variables:_
 Set the values accordingly before using this plugin.
 
 ## 3 Tips:
-_Trello board description managed by DevStream, don't modify it_
+_Trello board description is managed by DevStream, please don't modify it._
 
 To create a Trello API key and token, see [here](https://docs.servicenow.com/bundle/quebec-it-asset-management/page/product/software-asset-management2/task/generate-trello-apikey-token.html).
 
@@ -35,7 +35,7 @@ tools:
     # integration tool name
     api:
       name: trello
-      kanban: kanban-name
+      kanbanBoardName: kanban-name
     # main branch of the repo (to which branch the plugin will submit the workflows)
     branch: master
 ```

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -45,6 +45,7 @@ tools:
     repo: golang-demo
     api:
       name: trello
+      kanban: kanban-golang-demo
     branch: main
 - name: argocd-dev
   plugin:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -45,7 +45,7 @@ tools:
     repo: golang-demo
     api:
       name: trello
-      kanban: kanban-golang-demo
+      kanbanBoardName: kanban-golang-demo
     branch: main
 - name: argocd-dev
   plugin:

--- a/internal/pkg/plugin/trellogithub/helper.go
+++ b/internal/pkg/plugin/trellogithub/helper.go
@@ -67,7 +67,7 @@ func (gi *TrelloGithub) renderTemplate(workflow *Workflow) error {
 
 func buildState(tg *TrelloGithub, ti *TrelloItemId) map[string]interface{} {
 	res := make(map[string]interface{})
-	res["workflowDir"] = fmt.Sprintf("repos/%s/%s/contents/.github/workflows", tg.options.Owner, tg.options.Repo)
+	res["workflowDir"] = fmt.Sprintf("/repos/%s/%s/contents/.github/workflows", tg.options.Owner, tg.options.Repo)
 	res["boardId"] = ti.boardId
 	res["todoListId"] = ti.todoListId
 	res["doingListId"] = ti.doingListId
@@ -75,12 +75,12 @@ func buildState(tg *TrelloGithub, ti *TrelloItemId) map[string]interface{} {
 	return res
 }
 
-func (gi *TrelloGithub) buildReadState() (map[string]interface{}, error) {
+func (gi *TrelloGithub) buildReadState(api *Api) (map[string]interface{}, error) {
 	c, err := trello.NewClient()
 	if err != nil {
 		return nil, err
 	}
-	listIds, err := c.GetBoardIdAndListId()
+	listIds, err := c.GetBoardIdAndListId(gi.options.Owner, gi.options.Repo, api.Kanban)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/helper.go
+++ b/internal/pkg/plugin/trellogithub/helper.go
@@ -80,7 +80,7 @@ func (gi *TrelloGithub) buildReadState(api *Api) (map[string]interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	listIds, err := c.GetBoardIdAndListId(gi.options.Owner, gi.options.Repo, api.Kanban)
+	listIds, err := c.GetBoardIdAndListId(gi.options.Owner, gi.options.Repo, api.KanbanBoardName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/read.go
+++ b/internal/pkg/plugin/trellogithub/read.go
@@ -23,13 +23,13 @@ func Read(options *map[string]interface{}) (map[string]interface{}, error) {
 	for name, err := range retMap {
 		if err != nil {
 			errFlag = true
-			log.Errorf("The workflow/file %s got some error: %s.", name, err)
+			log.Errorf("The workflow/file %s got some error: %s", name, err)
 		}
-		log.Infof("The workflow/file %s is ok.", name)
+		log.Infof("The workflow/file %s is ok", name)
 	}
 	if errFlag {
 		return nil, nil
 	}
 
-	return gis.buildReadState()
+	return gis.buildReadState(api)
 }

--- a/internal/pkg/plugin/trellogithub/trellogithub.go
+++ b/internal/pkg/plugin/trellogithub/trellogithub.go
@@ -84,7 +84,7 @@ func (gi *TrelloGithub) CreateTrelloItems() (*TrelloItemId, error) {
 		return nil, err
 	}
 
-	board, err := c.CreateBoard(gi.options.Api.Kanban, gi.options.Owner, gi.options.Repo)
+	board, err := c.CreateBoard(gi.options.Api.KanbanBoardName, gi.options.Owner, gi.options.Repo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/trellogithub.go
+++ b/internal/pkg/plugin/trellogithub/trellogithub.go
@@ -84,8 +84,7 @@ func (gi *TrelloGithub) CreateTrelloItems() (*TrelloItemId, error) {
 		return nil, err
 	}
 
-	boardName := gi.options.Repo
-	board, err := c.CreateBoard(boardName)
+	board, err := c.CreateBoard(gi.options.Api.Kanban, gi.options.Owner, gi.options.Repo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/workflow.go
+++ b/internal/pkg/plugin/trellogithub/workflow.go
@@ -29,7 +29,8 @@ type Options struct {
 }
 
 type Api struct {
-	Name string
+	Name   string
+	Kanban string
 }
 
 // Workflow is the struct for a GitHub Actions Workflow.

--- a/internal/pkg/plugin/trellogithub/workflow.go
+++ b/internal/pkg/plugin/trellogithub/workflow.go
@@ -29,8 +29,8 @@ type Options struct {
 }
 
 type Api struct {
-	Name   string
-	Kanban string
+	Name            string
+	KanbanBoardName string
 }
 
 // Workflow is the struct for a GitHub Actions Workflow.

--- a/pkg/util/trello/trello.go
+++ b/pkg/util/trello/trello.go
@@ -5,12 +5,15 @@ import (
 	"os"
 
 	"github.com/adlio/trello"
+
 	"github.com/merico-dev/stream/internal/pkg/log"
 )
 
 type Client struct {
 	*trello.Client
 }
+
+const DefaultListsNumber = 3
 
 func NewClient() (*Client, error) {
 	helpUrl := "https://docs.servicenow.com/bundle/quebec-it-asset-management/page/product/software-asset-management2/task/generate-trello-apikey-token.html"
@@ -25,11 +28,14 @@ func NewClient() (*Client, error) {
 	}, nil
 }
 
-func (c *Client) CreateBoard(boardName string) (*trello.Board, error) {
-	if boardName == "" {
-		return nil, fmt.Errorf("board name can't be empty")
+func (c *Client) CreateBoard(kanban, owner, repo string) (*trello.Board, error) {
+	if kanban == "" {
+		kanban = fmt.Sprintf("%s/%s", owner, repo)
 	}
-	board := trello.NewBoard(boardName)
+
+	board := trello.NewBoard(kanban)
+	board.Desc = boardDesc(owner, repo)
+
 	err := c.Client.CreateBoard(&board, trello.Defaults())
 	if err != nil {
 		return nil, err
@@ -44,27 +50,41 @@ func (c *Client) CreateList(board *trello.Board, listName string) (*trello.List,
 	return c.Client.CreateList(board, listName, trello.Defaults())
 }
 
-func (c *Client) GetBoardIdAndListId() (map[string]interface{}, error) {
-	res := make(map[string]interface{})
+// GetBoardIdAndListId get the board, which board name == kanban, and board desc == owner/repo
+func (c *Client) GetBoardIdAndListId(owner, repo, kanban string) (map[string]interface{}, error) {
 
+	res := make(map[string]interface{})
 	bs, err := c.Client.GetMyBoards()
 	if err != nil {
 		return nil, err
 	}
 
 	for _, b := range bs {
-		lists, err := b.GetLists()
-		if err != nil {
-			return nil, err
+		if checkTargetBoard(owner, repo, kanban, b) {
+			lists, err := b.GetLists()
+			if err != nil {
+				return nil, err
+			}
+			if len(lists) != DefaultListsNumber {
+				log.Errorf("Unknown lists format: len==%d", len(lists))
+				return nil, fmt.Errorf("unknown lists format: len==%d", len(lists))
+			}
+			res["boardId"] = b.ID
+			res["todoListId"] = lists[0].ID
+			res["doingListId"] = lists[1].ID
+			res["doneListId"] = lists[2].ID
 		}
-		if len(lists) != 3 {
-			log.Errorf("Unknown lists format: len==%d.", len(lists))
-			return nil, fmt.Errorf("unknown lists format: len==%d", len(lists))
-		}
-		res["boardId"] = b.ID
-		res["todoListId"] = lists[0].ID
-		res["doingListId"] = lists[1].ID
-		res["doneListId"] = lists[2].ID
 	}
 	return res, nil
+}
+
+func checkTargetBoard(owner, repo, kanban string, b *trello.Board) bool {
+	if b.Name == kanban && b.Desc == boardDesc(owner, repo) {
+		return true
+	}
+	return false
+}
+
+func boardDesc(owner, repo string) string {
+	return fmt.Sprintf("Description managed by DevStream,don't change.%s/%s", owner, repo)
 }

--- a/pkg/util/trello/trello.go
+++ b/pkg/util/trello/trello.go
@@ -28,12 +28,12 @@ func NewClient() (*Client, error) {
 	}, nil
 }
 
-func (c *Client) CreateBoard(kanban, owner, repo string) (*trello.Board, error) {
-	if kanban == "" {
-		kanban = fmt.Sprintf("%s/%s", owner, repo)
+func (c *Client) CreateBoard(kanbanBoardName, owner, repo string) (*trello.Board, error) {
+	if kanbanBoardName == "" {
+		kanbanBoardName = fmt.Sprintf("%s/%s", owner, repo)
 	}
 
-	board := trello.NewBoard(kanban)
+	board := trello.NewBoard(kanbanBoardName)
 	board.Desc = boardDesc(owner, repo)
 
 	err := c.Client.CreateBoard(&board, trello.Defaults())
@@ -50,8 +50,8 @@ func (c *Client) CreateList(board *trello.Board, listName string) (*trello.List,
 	return c.Client.CreateList(board, listName, trello.Defaults())
 }
 
-// GetBoardIdAndListId get the board, which board name == kanban, and board desc == owner/repo
-func (c *Client) GetBoardIdAndListId(owner, repo, kanban string) (map[string]interface{}, error) {
+// GetBoardIdAndListId get the board, which board name == kanbanBoardName, and board desc == owner/repo
+func (c *Client) GetBoardIdAndListId(owner, repo, kanbanBoardName string) (map[string]interface{}, error) {
 
 	res := make(map[string]interface{})
 	bs, err := c.Client.GetMyBoards()
@@ -60,13 +60,13 @@ func (c *Client) GetBoardIdAndListId(owner, repo, kanban string) (map[string]int
 	}
 
 	for _, b := range bs {
-		if checkTargetBoard(owner, repo, kanban, b) {
+		if checkTargetBoard(owner, repo, kanbanBoardName, b) {
 			lists, err := b.GetLists()
 			if err != nil {
 				return nil, err
 			}
 			if len(lists) != DefaultListsNumber {
-				log.Errorf("Unknown lists format: len==%d", len(lists))
+				log.Errorf("Unknown lists format: len==%d.", len(lists))
 				return nil, fmt.Errorf("unknown lists format: len==%d", len(lists))
 			}
 			res["boardId"] = b.ID
@@ -78,13 +78,13 @@ func (c *Client) GetBoardIdAndListId(owner, repo, kanban string) (map[string]int
 	return res, nil
 }
 
-func checkTargetBoard(owner, repo, kanban string, b *trello.Board) bool {
-	if b.Name == kanban && b.Desc == boardDesc(owner, repo) {
+func checkTargetBoard(owner, repo, kanbanBoardName string, b *trello.Board) bool {
+	if b.Name == kanbanBoardName && b.Desc == boardDesc(owner, repo) {
 		return true
 	}
 	return false
 }
 
 func boardDesc(owner, repo string) string {
-	return fmt.Sprintf("Description managed by DevStream,don't change.%s/%s", owner, repo)
+	return fmt.Sprintf("Description is managed by DevStream, please don't modify. %s/%s", owner, repo)
 }


### PR DESCRIPTION
# Summary

## Description

1.  state file resource option: workflow dir lacks "/"
2. The board must be found in trello precisely, so we must get the boardid from state resource.
- if board found, list id(todo/doing/done) can be queried
3. add "kanban" in doc, so that to let user config the kanban name of trello


