### PR TITLE
Fix: skip the pv/sa/cr/crb creation when it already exists

### DIFF
--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -4,10 +4,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func init() {
-	logrus.SetLevel(logrus.InfoLevel)
-}
-
 var (
 	debugLog     = &CliLoggerFormatter{showType: "debug"}
 	infoLog      = &CliLoggerFormatter{showType: "info"}

--- a/internal/pkg/plugin/argocd/create.go
+++ b/internal/pkg/plugin/argocd/create.go
@@ -36,6 +36,7 @@ func Create(options *map[string]interface{}) (map[string]interface{}, error) {
 		if err = dealWithNsWhenInterruption(&param); err != nil {
 			log.Errorf("Failed to deal with namespace: %s.", err)
 		}
+		log.Debugf("Deal with namespace when interruption succeeded.")
 	}()
 
 	var h *helm.Helm

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -38,6 +38,7 @@ func Create(options *map[string]interface{}) (map[string]interface{}, error) {
 		if err = dealWithNsWhenInterruption(&param); err != nil {
 			log.Errorf("Failed to deal with namespace: %s.", err)
 		}
+		log.Debugf("Deal with namespace when interruption succeeded.")
 	}()
 
 	var h *helm.Helm

--- a/internal/pkg/plugin/jenkins/precreate.go
+++ b/internal/pkg/plugin/jenkins/precreate.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/merico-dev/stream/internal/pkg/log"
@@ -73,7 +74,10 @@ func createPersistentVolume(kubeClient *k8s.Client) error {
 	}
 
 	if err := kubeClient.CreatePersistentVolume(pvOption); err != nil {
-		return err
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Infof("The resource %s is already exists.", "PersistentVolume")
 	}
 
 	return nil
@@ -81,7 +85,10 @@ func createPersistentVolume(kubeClient *k8s.Client) error {
 
 func createServiceAccount(kubeClient *k8s.Client) error {
 	if err := kubeClient.CreateServiceAccount(JenkinsName, JenkinsNamespace); err != nil {
-		return err
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Infof("The resource %s is already exists.", "ServiceAccount")
 	}
 
 	return nil
@@ -144,7 +151,10 @@ func createClusterRole(kubeClient *k8s.Client) error {
 	}
 
 	if err := kubeClient.CreateClusterRole(crOption); err != nil {
-		return err
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Infof("The resource %s is already exists.", "ClusterRole")
 	}
 
 	return nil
@@ -158,7 +168,10 @@ func createClusterRoleBinding(kubeClient *k8s.Client) error {
 	}
 
 	if err := kubeClient.CreateClusterRoleBinding(crbOption); err != nil {
-		return err
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Infof("The resource %s is already exists.", "ClusterRoleBinding")
 	}
 
 	return nil

--- a/internal/pkg/plugin/kubeprometheus/create.go
+++ b/internal/pkg/plugin/kubeprometheus/create.go
@@ -36,6 +36,7 @@ func Create(options *map[string]interface{}) (map[string]interface{}, error) {
 		if err = dealWithNsWhenInterruption(&param); err != nil {
 			log.Errorf("Failed to deal with namespace: %s.", err)
 		}
+		log.Debugf("Deal with namespace when interruption succeeded.")
 	}()
 
 	var h *helm.Helm


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Skip the pv/sa/cr/crb creation when it already exists

## Related Issues

fix #215 
