### PR TITLE
Feat: clear all non-helm resources when Delete() & Create() failed.

### DIFF
--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -39,6 +39,11 @@ func Create(options *map[string]interface{}) (map[string]interface{}, error) {
 			log.Errorf("Failed to deal with namespace: %s.", err)
 		}
 		log.Debugf("Deal with namespace when interruption succeeded.")
+
+		// Clear all the resources have been created if the creation process interruption.
+		if err = postDelete(); err != nil {
+			log.Errorf("Failed to clear the resources have been created: %s.", err)
+		}
 	}()
 
 	var h *helm.Helm

--- a/internal/pkg/plugin/jenkins/delete.go
+++ b/internal/pkg/plugin/jenkins/delete.go
@@ -38,6 +38,11 @@ func Delete(options *map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
+	if err = postDelete(); err != nil {
+		log.Errorf("Failed to execute the post-delete logic. Error: %s.", err)
+		return false, err
+	}
+
 	return true, nil
 }
 

--- a/internal/pkg/plugin/jenkins/postdelete.go
+++ b/internal/pkg/plugin/jenkins/postdelete.go
@@ -1,0 +1,50 @@
+package jenkins
+
+import (
+	"github.com/merico-dev/stream/internal/pkg/log"
+	"github.com/merico-dev/stream/pkg/util/k8s"
+)
+
+func postDelete() error {
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if err = clearClusterRoleBinding(kubeClient); err != nil {
+		return err
+	}
+
+	if err = clearClusterRole(kubeClient); err != nil {
+		return err
+	}
+
+	if err = clearServiceAccount(kubeClient); err != nil {
+		return err
+	}
+
+	clearPersistentVolume()
+
+	return nil
+}
+
+func clearClusterRoleBinding(kubeClient *k8s.Client) error {
+	return kubeClient.DeleteClusterRoleBinding(JenkinsName)
+}
+
+func clearClusterRole(kubeClient *k8s.Client) error {
+	return kubeClient.DeleteClusterRole(JenkinsName)
+}
+
+func clearServiceAccount(kubeClient *k8s.Client) error {
+	return kubeClient.DeleteServiceAccount(JenkinsName, JenkinsNamespace)
+}
+
+func clearPersistentVolume() {
+	dataDir := getRealJenkinsDataDirectory()
+	log.Warnf("\n\nNOTICE!!!\n"+
+		"The PersistentVolume jenkins-pv is NOT been deleted.\n"+
+		"You can execute the \"kubectl delete pv jenkins-pv\" to delete it manually."+
+		"The local data directory %s is also NOT been deleted."+
+		"You can delete it manually.\n", dataDir)
+}

--- a/pkg/util/k8s/rbac.go
+++ b/pkg/util/k8s/rbac.go
@@ -21,11 +21,22 @@ func (c *Client) CreateServiceAccount(name, namespace string) error {
 
 	_, err := c.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
 	if err != nil {
-		log.Errorf("Failed to create ServiceAccount < %s >: %s.", sa.Name, err)
+		log.Errorf("Failed to create the ServiceAccount < %s >: %s.", sa.Name, err)
 		return err
 	}
 
-	log.Debugf("The ServiceAccount < %s > has created.", sa.Name)
+	log.Debugf("The ServiceAccount < %s > has been created.", sa.Name)
+	return nil
+}
+
+func (c *Client) DeleteServiceAccount(name, namespace string) error {
+	err := c.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Errorf("Failed to delete the ServiceAccount < %s >: %s.", name, err)
+		return err
+	}
+
+	log.Debugf("The ServiceAccount < %s > has been deleted.", name)
 	return nil
 }
 
@@ -44,11 +55,22 @@ func (c *Client) CreateClusterRole(option *CROption) error {
 
 	_, err := c.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
 	if err != nil {
-		log.Errorf("Failed to create ClusterRole < %s >: %s.", cr.Name, err)
+		log.Errorf("Failed to create the ClusterRole < %s >: %s.", cr.Name, err)
 		return err
 	}
 
-	log.Debugf("The ClusterRole < %s > has created.", cr.Name)
+	log.Debugf("The ClusterRole < %s > has been created.", cr.Name)
+	return nil
+}
+
+func (c *Client) DeleteClusterRole(name string) error {
+	err := c.RbacV1().ClusterRoles().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Errorf("Failed to delete the ClusterRole < %s >: %s.", name, err)
+		return err
+	}
+
+	log.Debugf("The ClusterRole < %s > has been deleted.", name)
 	return nil
 }
 
@@ -82,10 +104,21 @@ func (c *Client) CreateClusterRoleBinding(option *CRBOption) error {
 
 	_, err := c.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, metav1.CreateOptions{})
 	if err != nil {
-		log.Errorf("Failed to create ClusterRoleBinding < %s >: %s.", crb.Name, err)
+		log.Errorf("Failed to create the ClusterRoleBinding < %s >: %s.", crb.Name, err)
 		return err
 	}
 
-	log.Debugf("The ClusterRoleBinding < %s > has created.", crb.Name)
+	log.Debugf("The ClusterRoleBinding < %s > has been created.", crb.Name)
+	return nil
+}
+
+func (c *Client) DeleteClusterRoleBinding(name string) error {
+	err := c.RbacV1().ClusterRoleBindings().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Errorf("Failed to delete the ClusterRoleBinding < %s >: %s.", name, err)
+		return err
+	}
+
+	log.Debugf("The ClusterRoleBinding < %s > has been deleted.", name)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

clear all non-helm resources when Delete() & Create() failed.