### PR TITLE
Feat: sink the usage of `backend` into `statemanager`

### DIFF
--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/merico-dev/stream/internal/pkg/log"
-
-	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
@@ -25,21 +23,15 @@ func Apply(configFile string, continueDirectly bool) error {
 		return err
 	}
 
-	// use default local backend for now.
-	b, err := backend.GetBackend(backend.BackendLocal)
+	smgr, err := statemanager.NewManager()
 	if err != nil {
-		return err
-	}
-	// create a state manager using the default local backend
-	smgr, err := statemanager.NewManager(b)
-	if err != nil {
-		log.Debugf("Failed to get the manager. %s", err)
+		log.Debugf("Failed to get the manager: %s.", err)
 		return err
 	}
 
 	changes, err := GetChangesForApply(smgr, cfg)
 	if err != nil {
-		log.Debugf("Get changes for apply failed: %s", err)
+		log.Debugf("Get changes for apply failed: %s.", err)
 		return err
 	}
 	if len(changes) == 0 {

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/merico-dev/stream/internal/pkg/log"
-
-	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
@@ -25,13 +23,7 @@ func Remove(configFile string, continueDirectly bool) error {
 		return err
 	}
 
-	// use default local backend for now.
-	b, err := backend.GetBackend(backend.BackendLocal)
-	if err != nil {
-		return err
-	}
-	// create a state manager using the default local backend
-	smgr, err := statemanager.NewManager(b)
+	smgr, err := statemanager.NewManager()
 	if err != nil {
 		log.Debugf("Failed to get the manager: %s.", err)
 		return err

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -3,7 +3,6 @@ package pluginengine
 import (
 	"fmt"
 
-	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/log"
 	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
@@ -23,13 +22,7 @@ func Verify(configFile string) (bool, error) {
 		return false, err
 	}
 
-	// use default local backend for now.
-	b, err := backend.GetBackend(backend.BackendLocal)
-	if err != nil {
-		return false, err
-	}
-
-	smgr, err := statemanager.NewManager(b)
+	smgr, err := statemanager.NewManager()
 	if err != nil {
 		log.Debugf("Failed to get the manager: %s.", err)
 		return false, err

--- a/internal/pkg/pluginengine/pluginengine_test.go
+++ b/internal/pkg/pluginengine/pluginengine_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/backend/local"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/pluginengine"
@@ -17,15 +16,13 @@ import (
 var _ = Describe("Pluginengine", func() {
 	var (
 		smgr statemanager.Manager
+		err  error
 	)
 
 	BeforeEach(func() {
 		defer GinkgoRecover()
 
-		b, err := backend.GetBackend(backend.BackendLocal)
-		Expect(err).NotTo(HaveOccurred())
-
-		smgr, err = statemanager.NewManager(b)
+		smgr, err = statemanager.NewManager()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(smgr).NotTo(BeNil())
 		_, _ = GinkgoWriter.Write([]byte("new a statemanager"))
@@ -85,7 +82,7 @@ var _ = Describe("Pluginengine", func() {
 			Tools: []configloader.Tool{*getTool(name, kind, version)},
 		}
 
-		err := smgr.AddState(fmt.Sprintf("%s_%s", name, kind), statemanager.State{})
+		err = smgr.AddState(fmt.Sprintf("%s_%s", name, kind), statemanager.State{})
 		Expect(err).NotTo(HaveOccurred())
 		changes, _ := pluginengine.GetChangesForDelete(smgr, cfg)
 

--- a/internal/pkg/statemanager/manager.go
+++ b/internal/pkg/statemanager/manager.go
@@ -38,20 +38,27 @@ type manager struct {
 
 var m *manager
 
-func NewManager(backend backend.Backend) (Manager, error) {
+func NewManager() (Manager, error) {
 	if m != nil {
 		return m, nil
 	}
 
 	log.Debugf("The global manager m is not initialized.")
 
+	// use default local backend for now.
+	b, err := backend.GetBackend(backend.BackendLocal)
+	if err != nil {
+		log.Errorf("Failed to get the Backend: %s.", err)
+		return nil, err
+	}
+
 	m = &manager{
-		Backend:   backend,
+		Backend:   b,
 		statesMap: NewStatesMap(),
 	}
 
 	// Read the initial states data
-	data, err := backend.Read()
+	data, err := b.Read()
 	if err != nil {
 		log.Debugf("Failed to read data from backend: %s.", err)
 		return nil, err

--- a/internal/pkg/statemanager/manager_test.go
+++ b/internal/pkg/statemanager/manager_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/merico-dev/stream/internal/pkg/backend"
 	"github.com/merico-dev/stream/internal/pkg/backend/local"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
@@ -14,14 +13,11 @@ import (
 
 var _ = Describe("Statemanager", func() {
 	var smgr statemanager.Manager
+	var err error
 
 	Context("States", func() {
 		BeforeEach(func() {
-			b, err := backend.GetBackend(backend.BackendLocal)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(b).NotTo(BeNil())
-
-			smgr, err = statemanager.NewManager(b)
+			smgr, err = statemanager.NewManager()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(smgr).NotTo(BeNil())
 		})
@@ -35,7 +31,7 @@ var _ = Describe("Statemanager", func() {
 				Resource: map[string]interface{}{"a": "value"},
 			}
 
-			err := smgr.AddState(key, stateA)
+			err = smgr.AddState(key, stateA)
 			Expect(err).NotTo(HaveOccurred())
 
 			stateB := smgr.GetState(key)
@@ -49,7 +45,7 @@ var _ = Describe("Statemanager", func() {
 		})
 
 		AfterEach(func() {
-			err := os.RemoveAll(local.DefaultStateFile)
+			err = os.RemoveAll(local.DefaultStateFile)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

sink the use of `backend` into `statemanager`

old usage with `statemanager.NewManager()`

```go
	b, err := backend.GetBackend(backend.BackendLocal)
	if err != nil {
		return err
	}

	smgr, err := statemanager.NewManager(b)
```

new usage with `statemanager.NewManager()`

```go
	smgr, err := statemanager.NewManager()
```
