### PR TITLE
Bug fix GitHub repo scaffolding owner case sensitive

### DIFF
--- a/docs/plugins/github-repo-scaffolding-golang_plugin.md
+++ b/docs/plugins/github-repo-scaffolding-golang_plugin.md
@@ -21,7 +21,7 @@ tools:
     version: 0.0.1
   # options for the plugin
   options:
-    # the repo's owner. please use lowercase
+    # the repo's owner. It should be case-sensitive here; strictly use your GitHub user name.
     owner: daniel-hutao
     # the repo which you'd like to create
     repo: golang-demo

--- a/docs/plugins/github-repo-scaffolding-golang_plugin.md
+++ b/docs/plugins/github-repo-scaffolding-golang_plugin.md
@@ -21,7 +21,7 @@ tools:
     version: 0.0.1
   # options for the plugin
   options:
-    # the repo's owner
+    # the repo's owner. please use lowercase
     owner: daniel-hutao
     # the repo which you'd like to create
     repo: golang-demo

--- a/docs/plugins/github-repo-scaffolding-golang_plugin.md
+++ b/docs/plugins/github-repo-scaffolding-golang_plugin.md
@@ -10,7 +10,7 @@ This plugin installs github-repo-scaffolding-golang.
 
 ## 2 Usage:
 
-Please note that the `owner` parameter is case-sensitive.
+**Please note that the `owner` parameter is case-sensitive.**
 
 ```yaml
 tools:

--- a/docs/plugins/github-repo-scaffolding-golang_plugin.md
+++ b/docs/plugins/github-repo-scaffolding-golang_plugin.md
@@ -10,6 +10,8 @@ This plugin installs github-repo-scaffolding-golang.
 
 ## 2 Usage:
 
+Please note that the `owner` parameter is case-sensitive.
+
 ```yaml
 tools:
 # name of the instance with github-repo-scaffolding-golang

--- a/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
@@ -182,7 +182,7 @@ func replaceAppNameInPathStr(filePath, appName string) (string, error) {
 
 func buildState(param *Param) map[string]interface{} {
 	res := make(map[string]interface{})
-	res["owner"] = strings.ToLower(param.Owner)
+	res["owner"] = param.Owner
 	res["repoName"] = param.Repo
 	return res
 }

--- a/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
@@ -182,7 +182,7 @@ func replaceAppNameInPathStr(filePath, appName string) (string, error) {
 
 func buildState(param *Param) map[string]interface{} {
 	res := make(map[string]interface{})
-	res["owner"] = param.Owner
+	res["owner"] = strings.ToLower(param.Owner)
 	res["repoName"] = param.Repo
 	return res
 }

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -44,7 +45,7 @@ func buildReadState(param *Param) (map[string]interface{}, error) {
 	}
 
 	res := make(map[string]interface{})
-	res["owner"] = *repo.Owner.Login
+	res["owner"] = strings.ToLower(*repo.Owner.Login)
 	res["repoName"] = *repo.Name
 
 	return res, nil

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -45,7 +44,7 @@ func buildReadState(param *Param) (map[string]interface{}, error) {
 	}
 
 	res := make(map[string]interface{})
-	res["owner"] = strings.ToLower(*repo.Owner.Login)
+	res["owner"] = *repo.Owner.Login
 	res["repoName"] = *repo.Name
 
 	return res, nil

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -29,9 +29,6 @@ func generateAction(tool *configloader.Tool, action statemanager.ComponentAction
 }
 
 func drifted(a, b map[string]interface{}) bool {
-	log.Debugf("a: %v.", a)
-	log.Debugf("b: %v.", b)
-
 	// nil vs empty map
 	if cmp.Equal(a, b, cmpopts.EquateEmpty()) {
 		return false
@@ -56,6 +53,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 		} else {
 			// tool found in state
 			if drifted(tool.Options, state.Options) {
+				log.Debugf("Tool %s %s config options drifted from state.", tool.Name, tool.Plugin.Kind)
 				// tool's config differs from State's, Update
 				changes = append(changes, generateUpdateAction(&tool))
 				log.Infof("Change added: %s -> %s", tool.Name, statemanager.ActionUpdate)
@@ -73,6 +71,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 					changes = append(changes, generateCreateAction(&tool))
 					log.Infof("Change added: %s -> %s", tool.Name, statemanager.ActionCreate)
 				} else if drifted(resource, state.Resource) {
+					log.Debugf("Tool %s %s resource drifted from state.", tool.Name, tool.Plugin.Kind)
 					// resource drifted from state, Update
 					changes = append(changes, generateUpdateAction(&tool))
 					log.Infof("Change added: %s -> %s", tool.Name, statemanager.ActionUpdate)


### PR DESCRIPTION
# Summary

GitHub owner isn't strictly case-sensitive.

If your username is "IronCore864" but put "ironcore864" in the DTM config, creating repo and stuff would still work; but next time when you try to `dtm apply` again, the resource would return owner name "IronCore864" which differs from what's in the state "ironcore864", hence an "update" would be triggered, when nothing is needed here.

## The Fix

We have added a comment in the GitHub repo scaffolding plugin so that the user should put 

## Test after the Fix

```bash
tiexin@MBA ~/work/stream $ ./dtm apply
2022-02-25 11:18:09 ℹ [INFO]  Apply started.
2022-02-25 11:18:09 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-02-25 11:18:09 ℹ [INFO]  Change added: golang-demo-repo -> Create
Continue? [y/n]
Enter a value (Default is n): y

2022-02-25 11:18:11 ℹ [INFO]  Start executing the plan.
2022-02-25 11:18:11 ℹ [INFO]  Changes count: 1.
2022-02-25 11:18:11 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-02-25 11:18:11 ℹ [INFO]  Processing: golang-demo-repo -> Create ...
2022-02-25 11:18:14 ℹ [INFO]  Repo created.
2022-02-25 11:18:27 ✔ [SUCCESS]  Plugin golang-demo-repo Create done.
2022-02-25 11:18:27 ✔ [SUCCESS]  All plugins applied successfully.
2022-02-25 11:18:27 ✔ [SUCCESS]  Apply finished.
tiexin@MBA ~/work/stream $ ./dtm apply
2022-02-25 11:20:27 ℹ [INFO]  Apply started.
2022-02-25 11:20:27 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-02-25 11:20:27 ✔ [SUCCESS]  GitHub repo exists, repo is golang-demo, owner is IronCore864.
2022-02-25 11:20:27 ℹ [INFO]  No changes done since last apply. There is nothing to do.
2022-02-25 11:20:27 ✔ [SUCCESS]  Apply finished.
```