### PR TITLE
Refactor: move the `internal/pkg/version` inside the `cmd/devstream/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ build: fmt vet ## Build dtm & plugins locally.
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/github-repo-scaffolding-golang-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/reposcaffolding/github/golang/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/devlake-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/devlake/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/gitlabci-golang-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/gitlabci/golang
-	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/internal/pkg/version.VERSION=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
+	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 
 build-core: fmt vet ## Build dtm core only, without plugins, locally.
 	go mod tidy
-	go build -trimpath -gcflags="all=-N -l"  -ldflags "-X github.com/merico-dev/stream/internal/pkg/version.VERSION=${VERSION}" -o dtm ./cmd/devstream/
+	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 
 clean:
 	rm -rf .devstream

--- a/cmd/devstream/version.go
+++ b/cmd/devstream/version.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/merico-dev/stream/internal/pkg/version"
+	"github.com/merico-dev/stream/cmd/devstream/version"
 )
 
 var versionCMD = &cobra.Command{
@@ -16,5 +16,5 @@ var versionCMD = &cobra.Command{
 }
 
 func versionCMDFunc(cmd *cobra.Command, args []string) {
-	fmt.Println(version.VERSION)
+	fmt.Println(version.Version)
 }

--- a/cmd/devstream/version/version.go
+++ b/cmd/devstream/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// Version is the version of DevStream.
+// Assignment by the command:
+// `go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" \
+// -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/`
+// See the Makefile for more info.
+var Version string

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -1,5 +1,0 @@
-package version
-
-// VERSION is the version of DevStream.
-// Assignment by `go build -ldflags ...` command. See the Makefile for more info.
-var VERSION string


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Move the `internal/pkg/version` inside the `cmd/devstream/`

## Description

The `version` package is very very simple, with almost no logic, just a simple variable there. So it is unnecessary to put it under `internal/pkg`. 

But we can't put this line of code directly into `cmd/devstream/version.go`, because its different directory name and package name will cause the `go build xxx` failed. 

So it is still necessary to keep the `version` package, but this package can be hidden inside the `cmd/devstream`, so as to be less noticed by the code readers.

![image](https://user-images.githubusercontent.com/18692628/155741436-cc858f73-e47f-42ff-a56b-578ff800e343.png)