### PR TITLE
feat: `dtm apply` will delete tools that are no longer in the config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-core: fmt vet ## Build dtm core only, without plugins, locally.
 	go mod tidy
 	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 
-clean:
+clean: ## Remove local plugins and locally built artifacts.
 	rm -rf .devstream
 	rm -f dtm*
 	rm -rf build/working_dir

--- a/docs/config_state_resource_explanation.md
+++ b/docs/config_state_resource_explanation.md
@@ -1,0 +1,36 @@
+# Config, State, Resource Detailed Explanation and How We Manage Changes
+
+The architecture documentation explains how in general DevStream works. If you haven't read it yet, make sure you do that before continuing with this document.
+
+## 1. Config, State, and Resource
+
+Config
+- The _Config_ is a list of tools, defined in [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/configloader/config.go#L19).
+- Each _Tool_ has its Name, Plugin, and Options, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/configloader/config.go#L24).
+
+State
+
+- The _State_ is actually a map of states, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L21).
+- Each state in the map is a struct containing Name, Plugin, Options and Resource, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L14).
+
+Resource
+- We call what the plugin created a _Resource_, and the `Read()` interface of that plugin returns a description of that resource, which is in turn stored as part of the state.
+
+## 2. Changes for `dtm apply`
+
+When _applying_ a config file using `dtm`, here's what happens:
+
+- Read the _State_
+- For each _Tool_ defined in the _Config_, we compare the _Tool_, its _State_, and the _Resoruce_ it has created before (if the state exists). We create some changes based on that.
+- For each _State_ that doesn't have a _Tool_ in the _Config_, we generate a "Delete" change to delete the _Resource_. Since there isn't a _Tool_ in the config but there is a _State_, it means maybe the _Resource_ had been created previously then the user removed the _Tool_ from the _Config_, which means the user don't want the _Resource_ any more.
+
+## 3. Changes for `dtm delete`
+
+When _deleting_ using `dtm`, here's what happens:
+
+- Read the _Config_ only
+- For each _Tool_ defined in the _Config_, if there is a corresponding _State_, we generate a "Delete" change.
+
+## 4. Changes for `dtm destroy`
+
+TODO.

--- a/docs/config_state_resource_explanation.md
+++ b/docs/config_state_resource_explanation.md
@@ -11,7 +11,7 @@ Config
 State
 
 - The _State_ is actually a map of states, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L21).
-- Each state in the map is a struct containing Name, Plugin, Options and Resource, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L14).
+- Each state in the map is a struct containing Name, Plugin, Options, and Resource, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L14).
 
 Resource
 - We call what the plugin created a _Resource_, and the `Read()` interface of that plugin returns a description of that resource, which is in turn stored as part of the state.
@@ -22,7 +22,7 @@ When _applying_ a config file using `dtm`, here's what happens:
 
 - Read the _State_
 - For each _Tool_ defined in the _Config_, we compare the _Tool_, its _State_, and the _Resoruce_ it has created before (if the state exists). We create some changes based on that.
-- For each _State_ that doesn't have a _Tool_ in the _Config_, we generate a "Delete" change to delete the _Resource_. Since there isn't a _Tool_ in the config but there is a _State_, it means maybe the _Resource_ had been created previously then the user removed the _Tool_ from the _Config_, which means the user don't want the _Resource_ any more.
+- For each _State_ that doesn't have a _Tool_ in the _Config_, we generate a "Delete" change to delete the _Resource_. Since there isn't a _Tool_ in the config but there is a _State_, it means maybe the _Resource_ had been created previously then the user removed the _Tool_ from the _Config_, which means the user doesn't want the _Resource_ any more.
 
 ## 3. Changes for `dtm delete`
 

--- a/internal/pkg/configloader/validation.go
+++ b/internal/pkg/configloader/validation.go
@@ -7,10 +7,6 @@ import (
 )
 
 func (c *Config) Validate() []error {
-	if len(c.Tools) == 0 {
-		return []error{fmt.Errorf("config has no tools defined")}
-	}
-
 	retErrors := make([]error, 0)
 
 	for _, t := range c.Tools {


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.
- [x] Documentation (new or existing) is updated.

## Description

_Note that this is a breaking change._ See the following sections for more details.

### Current Behavior

If a _Tool_ had been created by `dtm`, then got deleted from the _Config_, `dtm apply` _wouldn't generate any change_ for it.

### New Behavior

If a _Tool_ had been created by `dtm`, then got deleted from the _Config_, `dtm apply` would _generate a "Delete" change_ for it.
