### PR TITLE
Fix: Makefile e2e stage error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 e2e: build ## Run e2e tests.
-	./dtm apply -f config.yaml
-	./dtm verify -f config.yaml
-	./dtm delete -f config.yaml
+	./dtm-${GOOS}-${GOARCH} apply -f config.yaml
+	./dtm-${GOOS}-${GOARCH} verify -f config.yaml
+	./dtm-${GOOS}-${GOARCH} delete -f config.yaml
 
 e2e-up: ## Start kind cluster for e2e tests
 	sh hack/e2e/e2e-up.sh


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Fix: Makefile e2e stage error

## Description

The `build` stage at the Makefile will generate the executable file `dtm-${GOOS}-${GOARCH}`.
So the e2e stage will fail to execute `./dtm apply -f config.yaml`.
It should be `dtm-${GOOS}-${GOARCH} apply -f config.yaml`.