### PR TITLE
Feat: `dtm destroy` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ To delete everything defined in the config, run:
 ./dtm delete -f examples/config.yaml
 ```
 
-_Note that this deletes everything defined in the config. If some config is deleted after apply (state has it but config not), `dtm delete` won't delete it. It differs from `dtm destroy` which will be implemented soon._
+_Note that this deletes everything defined in the config. If some config is deleted after apply (state has it but config not), `dtm delete` won't delete it. It differs from `dtm destroy`._
 
 Similarly, to delete without confirmation:
 
@@ -184,6 +184,14 @@ To verify, run:
 ```bash
 ./dtm verify -f examples/config.yaml
 ```
+
+To destroy everything, run:
+
+```bash
+./dtm destroy
+```
+
+_`dtm` will read the state, then determine which tools are installed, and then remove those tools. It's same as `dtm apply -f empty.yaml` (empty.yaml is an empty config file)._
 
 ## Architecture
 

--- a/cmd/devstream/destroy.go
+++ b/cmd/devstream/destroy.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/merico-dev/stream/internal/pkg/pluginengine"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+var destroyCMD = &cobra.Command{
+	Use:   "destroy",
+	Short: "Destroy DevOps tools deployment according to DevStream configuration file & state file",
+	Long:  `Destroy DevOps tools deployment according to DevStream configuration file & state file.`,
+	Run:   destroyCMDFunc,
+}
+
+func destroyCMDFunc(cmd *cobra.Command, args []string) {
+	log.Info("Destroy started.")
+	if err := pluginengine.Destroy(continueDirectly); err != nil {
+		log.Errorf("Destroy failed => %s.", err)
+		os.Exit(1)
+	}
+	log.Success("Destroy finished.")
+}

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -47,6 +47,7 @@ func init() {
 	rootCMD.AddCommand(initCMD)
 	rootCMD.AddCommand(applyCMD)
 	rootCMD.AddCommand(deleteCMD)
+	rootCMD.AddCommand(destroyCMD)
 	rootCMD.AddCommand(verifyCMD)
 }
 

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -1,0 +1,49 @@
+package pluginengine
+
+import (
+	"errors"
+	"os"
+
+	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/statemanager"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+func Destroy(continueDirectly bool) error {
+	emptyConfig := new(configloader.Config)
+
+	smgr, err := statemanager.NewManager()
+	if err != nil {
+		log.Debugf("Failed to get the manager: %s.", err)
+		return err
+	}
+
+	// GetChangesForApply with the empty config will return the changes all with "delete" action.
+	changes, err := GetChangesForApply(smgr, emptyConfig)
+	if err != nil {
+		log.Debugf("Get changes failed: %s.", err)
+		return err
+	}
+	if len(changes) == 0 {
+		log.Info("No tools have been deployed now. There is nothing to do.")
+		return nil
+	}
+
+	if !continueDirectly {
+		userInput := readUserInput()
+		if userInput == "n" {
+			os.Exit(0)
+		}
+	}
+
+	errsMap := execute(smgr, changes)
+	if len(errsMap) != 0 {
+		for k, e := range errsMap {
+			log.Infof("%s -> %s", k, e)
+		}
+		return errors.New("some error(s) occurred during plugins destroy process")
+	}
+
+	log.Success("All plugins destroyed successfully.")
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Feat: `dtm destroy` command

## Key Points

- [x] Documentation (new or existing) is updated.

## Description

![image](https://user-images.githubusercontent.com/18692628/156180608-b180cc9c-2416-42b7-8453-7d596d2d05e8.png)

```sh
# ./dtm-darwin-arm64 destroy                                                      
2022-03-01 21:35:30 ℹ [INFO]  Destroy started.
2022-03-01 21:35:30 ℹ [INFO]  Change added: golang-demo1_github-repo-scaffolding-golang -> Delete
Continue? [y/n]
Enter a value (Default is n): y

2022-03-01 21:35:35 ℹ [INFO]  Start executing the plan.
2022-03-01 21:35:35 ℹ [INFO]  Changes count: 1.
2022-03-01 21:35:35 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-01 21:35:35 ℹ [INFO]  Processing: golang-demo1 -> Delete ...
2022-03-01 21:35:37 ✔ [SUCCESS]  GitHub repo golang-demo removed.
2022-03-01 21:35:37 ℹ [INFO]  Prepare to delete 'golang-demo1_github-repo-scaffolding-golang' from States.
2022-03-01 21:35:37 ✔ [SUCCESS]  Plugin golang-demo1 delete done.
2022-03-01 21:35:37 ✔ [SUCCESS]  All plugins destroyed successfully.
2022-03-01 21:35:37 ✔ [SUCCESS]  Destroy finished.

```

execute again:

```sh
# ./dtm-darwin-arm64 destroy
2022-03-01 21:59:31 ℹ [INFO]  Destroy started.
2022-03-01 21:59:31 ℹ [INFO]  No changes here. There is nothing to do.
2022-03-01 21:59:31 ✔ [SUCCESS]  Destroy finished.
```
