### PR TITLE
Fix: change the *map to map at params

### DIFF
--- a/cmd/argocd/main.go
+++ b/cmd/argocd/main.go
@@ -12,22 +12,22 @@ const NAME = "argocd"
 type Plugin string
 
 // Create implements the create of ArgoCD.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocd.Create(options)
 }
 
 // Update implements the update of ArgoCD.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocd.Update(options)
 }
 
 // Delete implements the delete of ArgoCD.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return argocd.Delete(options)
 }
 
 // Read implements the read of ArgoCD.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocd.Read(options)
 }
 

--- a/cmd/argocdapp/main.go
+++ b/cmd/argocdapp/main.go
@@ -12,22 +12,22 @@ const NAME = "argocdapps"
 type Plugin string
 
 // Create implements the installation of an ArgoCD app.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocdapp.Create(options)
 }
 
 // Update implements the installation of an ArgoCD app.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocdapp.Update(options)
 }
 
 // Read implements the healthy check of ArgoCD app.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return argocdapp.Read(options)
 }
 
 // Delete Deletes the installation of an ArgoCD app.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return argocdapp.Delete(options)
 }
 

--- a/cmd/devlake/main.go
+++ b/cmd/devlake/main.go
@@ -12,22 +12,22 @@ const NAME = "devlake"
 type Plugin string
 
 // Create implements the installation of DevLake.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return devlake.Create(options)
 }
 
 // Update implements the installation of DevLake.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return devlake.Update(options)
 }
 
 // Read implements the healthy check of DevLake.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return devlake.Read(options)
 }
 
 // Delete Uninstall the installation of DevLake.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return devlake.Delete(options)
 }
 

--- a/cmd/githubactions/golang/main.go
+++ b/cmd/githubactions/golang/main.go
@@ -12,22 +12,22 @@ const NAME = "githubactions-golang"
 type Plugin string
 
 // Create implements the installation of some GitHub Actions workflows.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Create(options)
 }
 
 // Update implements the installation of some GitHub Actions workflows.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Update(options)
 }
 
 // Read implements the healthy check of GitHub Actions workflows.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Read(options)
 }
 
 // Delete implements the installation of some GitHub Actions workflows.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return golang.Delete(options)
 }
 

--- a/cmd/githubactions/nodejs/main.go
+++ b/cmd/githubactions/nodejs/main.go
@@ -12,22 +12,22 @@ const NAME = "githubactions-nodejs"
 type Plugin string
 
 // Create implements the installation of some GitHub Actions workflows.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return nodejs.Create(options)
 }
 
 // Update implements the installation of some GitHub Actions workflows.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return nodejs.Update(options)
 }
 
 // Read implements the healthy check of GitHub Actions workflows.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return nodejs.Read(options)
 }
 
 // Delete implements the installation of some GitHub Actions workflows.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return nodejs.Delete(options)
 }
 

--- a/cmd/githubactions/python/main.go
+++ b/cmd/githubactions/python/main.go
@@ -12,22 +12,22 @@ const NAME = "githubactions-python"
 type Plugin string
 
 // Create implements the installation of some GitHub Actions workflows.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return python.Create(options)
 }
 
 // Update implements the installation of some GitHub Actions workflows.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return python.Update(options)
 }
 
 // Read implements the healthy check of GitHub Actions workflows.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return python.Read(options)
 }
 
 // Delete implements the installation of some GitHub Actions workflows.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return python.Delete(options)
 }
 

--- a/cmd/gitlabci/golang/main.go
+++ b/cmd/gitlabci/golang/main.go
@@ -12,22 +12,22 @@ const NAME = "gitlabci-golang"
 type Plugin string
 
 // Create creates a GitLab CI workflow for Golang.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Create(options)
 }
 
 // Update updates the GitLab CI workflow for Golang.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Update(options)
 }
 
 // Read gets the state of the GitLab CI workflow for Golang.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Read(options)
 }
 
 // Delete deletes the GitLab CI workflow.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return golang.Delete(options)
 }
 

--- a/cmd/jenkins/main.go
+++ b/cmd/jenkins/main.go
@@ -12,22 +12,22 @@ const NAME = "jenkins"
 type Plugin string
 
 // Create implements the create of the jenkins.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return jenkins.Create(options)
 }
 
 // Update implements the update of the jenkins.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return jenkins.Update(options)
 }
 
 // Read implements read of the jenkins.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return jenkins.Read(options)
 }
 
 // Delete implements the delete of the jenkins.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return jenkins.Delete(options)
 }
 

--- a/cmd/kubeprometheus/main.go
+++ b/cmd/kubeprometheus/main.go
@@ -12,22 +12,22 @@ const NAME = "kube-prometheus"
 type Plugin string
 
 // Create implements the create of the kube-prometheus.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return kubeprometheus.Create(options)
 }
 
 // Update implements the update of the kube-prometheus.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return kubeprometheus.Update(options)
 }
 
 // Read implements read of the kube-prometheus.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return kubeprometheus.Read(options)
 }
 
 // Delete implements the delete of the kube-prometheus.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return kubeprometheus.Delete(options)
 }
 

--- a/cmd/reposcaffolding/github/golang/main.go
+++ b/cmd/reposcaffolding/github/golang/main.go
@@ -13,22 +13,22 @@ const NAME = "github-repo-scaffolding-golang"
 type Plugin string
 
 // Create implements the installation of the github-repo-scaffolding-golang.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Create(options)
 }
 
 // Update implements the reinstallation of the github-repo-scaffolding-golang.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Update(options)
 }
 
 // Read implements the healthy check of the github-repo-scaffolding-golang.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return golang.Read(options)
 }
 
 // Delete implements the uninstallation of the github-repo-scaffolding-golang.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return golang.Delete(options)
 }
 

--- a/cmd/trellogithub/main.go
+++ b/cmd/trellogithub/main.go
@@ -12,22 +12,22 @@ const NAME = "trellogithub"
 type Plugin string
 
 // Create implements the installation of some trello-github-integ workflows.
-func (p Plugin) Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
 	return trellogithub.Create(options)
 }
 
 // Update implements the installation of some trello-github-integ workflows.
-func (p Plugin) Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return trellogithub.Update(options)
 }
 
 // Read implements the healthy check of trello-github-integ workflows.
-func (p Plugin) Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
 	return trellogithub.Read(options)
 }
 
 // Delete implements the installation of some trello-github-integ workflows.
-func (p Plugin) Delete(options *map[string]interface{}) (bool, error) {
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
 	return trellogithub.Delete(options)
 }
 

--- a/internal/pkg/plugin/argocd/create.go
+++ b/internal/pkg/plugin/argocd/create.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Create creates ArgoCD with provided options.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/argocd/delete.go
+++ b/internal/pkg/plugin/argocd/delete.go
@@ -11,9 +11,9 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/argocd/read.go
+++ b/internal/pkg/plugin/argocd/read.go
@@ -16,9 +16,9 @@ const (
 	ArgocdDefaultNamespace = "argocd"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/argocd/update.go
+++ b/internal/pkg/plugin/argocd/update.go
@@ -4,7 +4,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	_, err := Delete(options)
 	if err != nil {
 		log.Errorf("Failed to delete the ArgoCD: %s.", err)

--- a/internal/pkg/plugin/argocdapp/create.go
+++ b/internal/pkg/plugin/argocdapp/create.go
@@ -11,11 +11,11 @@ import (
 )
 
 // Create creates an ArgoCD app YAML and applys it.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/argocdapp/delete.go
+++ b/internal/pkg/plugin/argocdapp/delete.go
@@ -10,11 +10,11 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/plugin/argocdapp/read.go
+++ b/internal/pkg/plugin/argocdapp/read.go
@@ -10,11 +10,11 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/argocdapp/update.go
+++ b/internal/pkg/plugin/argocdapp/update.go
@@ -1,5 +1,5 @@
 package argocdapp
 
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return Create(options)
 }

--- a/internal/pkg/plugin/devlake/create.go
+++ b/internal/pkg/plugin/devlake/create.go
@@ -12,11 +12,11 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/devlake/delete.go
+++ b/internal/pkg/plugin/devlake/delete.go
@@ -10,11 +10,11 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/plugin/devlake/read.go
+++ b/internal/pkg/plugin/devlake/read.go
@@ -8,11 +8,11 @@ const (
 	DevLakeTotalK8sDeployments = 4
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
 
 	// decode input parameters into a struct
-	err := mapstructure.Decode(*options, &param)
+	err := mapstructure.Decode(options, &param)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/devlake/update.go
+++ b/internal/pkg/plugin/devlake/update.go
@@ -1,5 +1,5 @@
 package devlake
 
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	return Create(options)
 }

--- a/internal/pkg/plugin/githubactions/golang/create.go
+++ b/internal/pkg/plugin/githubactions/golang/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Create sets up GitHub Actions workflow(s).
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/golang/delete.go
+++ b/internal/pkg/plugin/githubactions/golang/delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Delete remove GitHub Actions workflows.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return false, err

--- a/internal/pkg/plugin/githubactions/golang/helper.go
+++ b/internal/pkg/plugin/githubactions/golang/helper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func parseAndValidateOptions(options *map[string]interface{}) (*Options, error) {
+func parseAndValidateOptions(options map[string]interface{}) (*Options, error) {
 	var opt Options
 	err := mapstructure.Decode(options, &opt)
 	if err != nil {

--- a/internal/pkg/plugin/githubactions/golang/read.go
+++ b/internal/pkg/plugin/githubactions/golang/read.go
@@ -6,7 +6,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/golang/update.go
+++ b/internal/pkg/plugin/githubactions/golang/update.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Update remove and set up GitHub Actions workflows.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/nodejs/create.go
+++ b/internal/pkg/plugin/githubactions/nodejs/create.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Create sets up GitHub Actions workflow(s).
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/nodejs/delete.go
+++ b/internal/pkg/plugin/githubactions/nodejs/delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Delete remove GitHub Actions workflows.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return false, err

--- a/internal/pkg/plugin/githubactions/nodejs/helper.go
+++ b/internal/pkg/plugin/githubactions/nodejs/helper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func parseAndValidateOptions(options *map[string]interface{}) (*Options, error) {
+func parseAndValidateOptions(options map[string]interface{}) (*Options, error) {
 	var opt Options
 	err := mapstructure.Decode(options, &opt)
 	if err != nil {

--- a/internal/pkg/plugin/githubactions/nodejs/read.go
+++ b/internal/pkg/plugin/githubactions/nodejs/read.go
@@ -6,7 +6,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/nodejs/update.go
+++ b/internal/pkg/plugin/githubactions/nodejs/update.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Update remove and set up GitHub Actions workflows.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/python/create.go
+++ b/internal/pkg/plugin/githubactions/python/create.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Create sets up GitHub Actions workflow(s).
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/python/delete.go
+++ b/internal/pkg/plugin/githubactions/python/delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Delete remove GitHub Actions workflows.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return false, err

--- a/internal/pkg/plugin/githubactions/python/helper.go
+++ b/internal/pkg/plugin/githubactions/python/helper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func parseAndValidateOptions(options *map[string]interface{}) (*Options, error) {
+func parseAndValidateOptions(options map[string]interface{}) (*Options, error) {
 	var opt Options
 	err := mapstructure.Decode(options, &opt)
 	if err != nil {

--- a/internal/pkg/plugin/githubactions/python/read.go
+++ b/internal/pkg/plugin/githubactions/python/read.go
@@ -6,7 +6,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/githubactions/python/update.go
+++ b/internal/pkg/plugin/githubactions/python/update.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Update remove and set up GitHub Actions workflows.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/gitlabci/golang/create.go
+++ b/internal/pkg/plugin/gitlabci/golang/create.go
@@ -2,7 +2,7 @@ package golang
 
 import "github.com/merico-dev/stream/pkg/util/gitlab"
 
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/gitlabci/golang/delete.go
+++ b/internal/pkg/plugin/gitlabci/golang/delete.go
@@ -2,7 +2,7 @@ package golang
 
 import "github.com/merico-dev/stream/pkg/util/gitlab"
 
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return false, err

--- a/internal/pkg/plugin/gitlabci/golang/gitlabci.go
+++ b/internal/pkg/plugin/gitlabci/golang/gitlabci.go
@@ -18,7 +18,7 @@ type Options struct {
 	Branch            string
 }
 
-func parseAndValidateOptions(options *map[string]interface{}) (*Options, error) {
+func parseAndValidateOptions(options map[string]interface{}) (*Options, error) {
 	var opt Options
 	err := mapstructure.Decode(options, &opt)
 	if err != nil {

--- a/internal/pkg/plugin/gitlabci/golang/read.go
+++ b/internal/pkg/plugin/gitlabci/golang/read.go
@@ -2,7 +2,7 @@ package golang
 
 import "github.com/merico-dev/stream/pkg/util/gitlab"
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/gitlabci/golang/update.go
+++ b/internal/pkg/plugin/gitlabci/golang/update.go
@@ -2,7 +2,7 @@ package golang
 
 import "github.com/merico-dev/stream/pkg/util/gitlab"
 
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	opt, err := parseAndValidateOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Create creates jenkins with provided options.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/jenkins/delete.go
+++ b/internal/pkg/plugin/jenkins/delete.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Delete deletes jenkins with provided options.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/jenkins/read.go
+++ b/internal/pkg/plugin/jenkins/read.go
@@ -17,9 +17,9 @@ const (
 )
 
 // Read reads the state for jenkins with provided options.
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/jenkins/update.go
+++ b/internal/pkg/plugin/jenkins/update.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Update updates jenkins with provided options.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	_, err := Delete(options)
 	if err != nil {
 		log.Errorf("Failed to delete the Jenkins: %s.", err)

--- a/internal/pkg/plugin/kubeprometheus/create.go
+++ b/internal/pkg/plugin/kubeprometheus/create.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Create creates kube-prometheus with provided options.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/kubeprometheus/delete.go
+++ b/internal/pkg/plugin/kubeprometheus/delete.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Delete deletes kube-prometheus with provided options.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/kubeprometheus/read.go
+++ b/internal/pkg/plugin/kubeprometheus/read.go
@@ -17,9 +17,9 @@ const (
 )
 
 // Read reads the state for kube-prometheus with provided options.
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/kubeprometheus/update.go
+++ b/internal/pkg/plugin/kubeprometheus/update.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Update updates kube-prometheus with provided options.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	_, err := Delete(options)
 	if err != nil {
 		log.Errorf("Failed to delete the kube-prometheus: %s", err)

--- a/internal/pkg/plugin/reposcaffolding/github/golang/create.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/create.go
@@ -13,9 +13,9 @@ import (
 )
 
 // Create installs github-repo-scaffolding-golang with provided options.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/reposcaffolding/github/golang/delete.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/delete.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Delete uninstalls github-repo-scaffolding-golang with provided options.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return false, err
 	}
 

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Read check the health for github-repo-scaffolding-golang with provided options.
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/reposcaffolding/github/golang/update.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/update.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Update re-installs github-repo-scaffolding-golang with provided options.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	var param Param
-	if err := mapstructure.Decode(*options, &param); err != nil {
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/trellogithub/create.go
+++ b/internal/pkg/plugin/trellogithub/create.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Create sets up trello-github-integ workflows.
-func Create(options *map[string]interface{}) (map[string]interface{}, error) {
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	gis, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/trellogithub/delete.go
+++ b/internal/pkg/plugin/trellogithub/delete.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Delete remove trello-github-integ workflows.
-func Delete(options *map[string]interface{}) (bool, error) {
+func Delete(options map[string]interface{}) (bool, error) {
 	gis, err := NewTrelloGithub(options)
 	if err != nil {
 		return false, err

--- a/internal/pkg/plugin/trellogithub/read.go
+++ b/internal/pkg/plugin/trellogithub/read.go
@@ -4,7 +4,7 @@ import (
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-func Read(options *map[string]interface{}) (map[string]interface{}, error) {
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	gis, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/trellogithub/trellogithub.go
+++ b/internal/pkg/plugin/trellogithub/trellogithub.go
@@ -26,11 +26,11 @@ type TrelloItemId struct {
 	doneListId  string
 }
 
-func NewTrelloGithub(options *map[string]interface{}) (*TrelloGithub, error) {
+func NewTrelloGithub(options map[string]interface{}) (*TrelloGithub, error) {
 	ctx := context.Background()
 
 	var opt Options
-	err := mapstructure.Decode(*options, &opt)
+	err := mapstructure.Decode(options, &opt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/update.go
+++ b/internal/pkg/plugin/trellogithub/update.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Update remove and set up trello-github-integ workflows.
-func Update(options *map[string]interface{}) (map[string]interface{}, error) {
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	gis, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/pluginengine/plugin.go
+++ b/internal/pkg/pluginengine/plugin.go
@@ -9,11 +9,11 @@ const DefaultPluginDir = ".devstream"
 // DevStreamPlugin is a struct, on which Create/Read/Update/Delete interfaces are defined.
 type DevStreamPlugin interface {
 	// Create, Read, and Update return two results, the first being the "state"
-	Create(*map[string]interface{}) (map[string]interface{}, error)
-	Read(*map[string]interface{}) (map[string]interface{}, error)
-	Update(*map[string]interface{}) (map[string]interface{}, error)
+	Create(map[string]interface{}) (map[string]interface{}, error)
+	Read(map[string]interface{}) (map[string]interface{}, error)
+	Update(map[string]interface{}) (map[string]interface{}, error)
 	// Delete returns (true, nil) if there is no error; otherwise it returns (false, error)
-	Delete(*map[string]interface{}) (bool, error)
+	Delete(map[string]interface{}) (bool, error)
 }
 
 // Create loads the plugin and calls the Create method of that plugin.
@@ -23,7 +23,7 @@ func Create(tool *configloader.Tool) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.Create(&tool.Options)
+	return p.Create(tool.Options)
 }
 
 // Update loads the plugin and calls the Update method of that plugin.
@@ -33,7 +33,7 @@ func Update(tool *configloader.Tool) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.Update(&tool.Options)
+	return p.Update(tool.Options)
 }
 
 func Read(tool *configloader.Tool) (map[string]interface{}, error) {
@@ -42,7 +42,7 @@ func Read(tool *configloader.Tool) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.Read(&tool.Options)
+	return p.Read(tool.Options)
 }
 
 // Delete loads the plugin and calls the Delete method of that plugin.
@@ -52,5 +52,5 @@ func Delete(tool *configloader.Tool) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return p.Delete(&tool.Options)
+	return p.Delete(tool.Options)
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Fix: change the *map to map at params

## Description

`map[string]interface{}` is better than `*map[string]interface{}`

### New Behavior

works well now.

```sh
./dtm-darwin-arm64 apply -f config-github-reposcaffolding-golang.yaml
2022-03-01 22:10:45 ℹ [INFO]  Apply started.
2022-03-01 22:10:45 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-01 22:10:45 ℹ [INFO]  Change added: golang-demo1 -> Create
Continue? [y/n]
Enter a value (Default is n): y

2022-03-01 22:10:46 ℹ [INFO]  Start executing the plan.
2022-03-01 22:10:46 ℹ [INFO]  Changes count: 1.
2022-03-01 22:10:46 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-01 22:10:46 ℹ [INFO]  Processing: golang-demo1 -> Create ...
2022-03-01 22:10:55 ℹ [INFO]  Repo created.
2022-03-01 22:11:13 ✔ [SUCCESS]  Plugin golang-demo1 Create done.
2022-03-01 22:11:13 ✔ [SUCCESS]  All plugins applied successfully.
2022-03-01 22:11:13 ✔ [SUCCESS]  Apply finished.

```

### Screenshots

![截屏2022-03-01 下午10 18 27](https://user-images.githubusercontent.com/18692628/156185746-ef9d2008-4c81-46dc-b729-fc275baa0b1c.png)

