### PR TITLE
Feat: add jira-github-integ plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build: fmt vet ## Build dtm & plugins locally.
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/github-repo-scaffolding-golang-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/reposcaffolding/github/golang/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/devlake-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/devlake/
 	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/gitlabci-golang-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/gitlabci/golang
+	go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/jira-github-integ-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/jiragithub/
 	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 
 build-core: fmt vet ## Build dtm core only, without plugins, locally.

--- a/build/package/build_linux_amd64.sh
+++ b/build/package/build_linux_amd64.sh
@@ -10,6 +10,7 @@ go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/githubaction
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/githubactions-python-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/githubactions/python
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/githubactions-nodejs-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/githubactions/nodejs
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/trello-github-integ-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/trellogithub/
+go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/jira-github-integ-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/jiragithub/
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/argocd-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/argocd/
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/argocdapp-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/argocdapp/
 go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o output/jenkins-${GOOS}-${GOARCH}_${VERSION}.so ./cmd/jenkins/

--- a/cmd/jiragithub/main.go
+++ b/cmd/jiragithub/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/merico-dev/stream/internal/pkg/plugin/jiragithub"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+// NAME is the name of this DevStream plugin.
+const NAME = "jiragithub"
+
+// Plugin is the type used by DevStream core. It's a string.
+type Plugin string
+
+// Create implements the installation of some jira-github-integ workflows.
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
+	return jiragithub.Create(options)
+}
+
+// Update implements the installation of some jira-github-integ workflows.
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
+	return jiragithub.Update(options)
+}
+
+// Read implements the healthy check of jira-github-integ workflows.
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
+	return jiragithub.Read(options)
+}
+
+// Delete implements the installation of some jira-github-integ workflows.
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
+	return jiragithub.Delete(options)
+}
+
+// DevStreamPlugin is the exported variable used by the DevStream core.
+var DevStreamPlugin Plugin
+
+func main() {
+	log.Infof("%T: %s is a plugin for DevStream. Use it with DevStream.\n", NAME, DevStreamPlugin)
+}

--- a/docs/plugins/jira-github-integ_plugin.md
+++ b/docs/plugins/jira-github-integ_plugin.md
@@ -1,0 +1,48 @@
+## 1 `jira-github-integ` Plugin
+
+This plugin integrates Jira with your GitHub repo.
+
+## 2 Usage:
+
+_Please confirm the preconditions:_
+
+- Jira language must be English
+- There should be an existing Jira project
+
+_This plugin depends on the following two environment variables:_
+
+- JIRA_API_TOKEN
+- GITHUB_TOKEN
+
+Set the values accordingly before using this plugin.
+
+
+To create a Jira API token, see [here](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
+
+```yaml
+tools:
+- name: jira-github-integ-default
+  # plugin profile
+  plugin:
+    # kind of this plugin
+    kind: jira-github-integ
+    # version of the plugin
+    version: 0.3.0
+  # options for the plugin
+  # checkout the version from the GitHub releases
+  options:
+    # the repo's owner
+    owner: lfbdev
+    # the repo where you'd like to setup GitHub Actions
+    repo: opendeveloper
+    # "base url: https://id.atlassian.net"
+    jiraBaseUrl: https://merico.atlassian.net
+    # "need real user email in cloud Jira"
+    jiraUserEmail: fangbao.li@merico.dev
+    # "get it from project url, like 'HEAP' from https://merico.atlassian.net/jira/software/projects/HEAP/pages"
+    jiraProjectKey: HEAP 
+    # main branch of the repo (to which branch the plugin will submit the workflows)
+    branch: master
+```
+
+Currently, all the parameters in the example above are mandatory.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -47,6 +47,17 @@ tools:
       name: trello
       kanbanBoardName: kanban-golang-demo
     branch: main
+- name: jira-github-integ-golang-demo
+  plugin:
+    kind: jira-github-integ
+    version: 0.2.0
+  options:
+    owner: ironcore864
+    repo:  golang-demo
+    jiraBaseUrl: https://merico.atlassian.net # "base url: https://id.atlassian.net"
+    jiraUserEmail: fangbao.li@merico.dev # "need real user email in cloud Jira"
+    jiraProjectKey: PROJECT  # "get it from project url, like 'DTM' from https://merico.atlassian.net/jira/software/projects/DTM/pages"
+    branch: main
 - name: argocd-dev
   plugin:
     kind: argocd

--- a/internal/pkg/plugin/jiragithub/create.go
+++ b/internal/pkg/plugin/jiragithub/create.go
@@ -1,0 +1,47 @@
+package jiragithub
+
+import (
+	"fmt"
+
+	"github.com/merico-dev/stream/pkg/util/github"
+)
+
+// Create sets up jira-github-integ workflows.
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
+	opt, err := parseAndValidateOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	ghOptions := &github.Option{
+		Owner:    opt.Owner,
+		Repo:     opt.Repo,
+		NeedAuth: true,
+	}
+	ghClient, err := github.NewClient(ghOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := renderTemplate(workflow, opt)
+	if err != nil {
+		return nil, err
+	}
+	workflow.WorkflowContent = content
+
+	if err := ghClient.AddWorkflow(workflow, opt.Branch); err != nil {
+		return nil, err
+	}
+
+	if err := setRepoSecrets(ghClient); err != nil {
+		return nil, err
+	}
+
+	return BuildState(opt.Owner, opt.Repo), nil
+}
+
+func BuildState(owner, repo string) map[string]interface{} {
+	res := make(map[string]interface{})
+	res["workflowDir"] = fmt.Sprintf("/repos/%s/%s/contents/.github/workflows", owner, repo)
+	return res
+}

--- a/internal/pkg/plugin/jiragithub/delete.go
+++ b/internal/pkg/plugin/jiragithub/delete.go
@@ -1,0 +1,29 @@
+package jiragithub
+
+import (
+	"github.com/merico-dev/stream/pkg/util/github"
+)
+
+// Delete remove jira-github-integ workflows.
+func Delete(options map[string]interface{}) (bool, error) {
+	opt, err := parseAndValidateOptions(options)
+	if err != nil {
+		return false, err
+	}
+
+	ghOptions := &github.Option{
+		Owner:    opt.Owner,
+		Repo:     opt.Repo,
+		NeedAuth: true,
+	}
+	ghClient, err := github.NewClient(ghOptions)
+	if err != nil {
+		return false, err
+	}
+
+	if err := ghClient.DeleteWorkflow(workflow, opt.Branch); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/pkg/plugin/jiragithub/helper.go
+++ b/internal/pkg/plugin/jiragithub/helper.go
@@ -1,0 +1,42 @@
+package jiragithub
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+
+	"github.com/merico-dev/stream/pkg/util/github"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+func parseAndValidateOptions(options map[string]interface{}) (*Options, error) {
+	var opt Options
+	err := mapstructure.Decode(options, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	if errs := validate(&opt); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Param error: %s.", e)
+		}
+		return nil, fmt.Errorf("incorrect params")
+	}
+
+	return &opt, nil
+}
+
+func setRepoSecrets(gitHubClient *github.Client) error {
+
+	// JIRA_API_TOKEN, how to get it: "https://help.siteimprove.com/support/solutions/articles/80000448174-how-to-create-an-api-token-from-your-atlassian-account"
+	if err := gitHubClient.AddRepoSecret("JIRA_API_TOKEN", viper.GetString("jira_api_token")); err != nil {
+		return err
+	}
+
+	if err := gitHubClient.AddRepoSecret("GH_TOKEN", viper.GetString("github_token")); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/pkg/plugin/jiragithub/options.go
+++ b/internal/pkg/plugin/jiragithub/options.go
@@ -1,0 +1,11 @@
+package jiragithub
+
+// Options is the struct for configurations of the jiragithub plugin.
+type Options struct {
+	Owner          string
+	Repo           string
+	JiraBaseUrl    string
+	JiraUserEmail  string
+	JiraProjectKey string
+	Branch         string
+}

--- a/internal/pkg/plugin/jiragithub/read.go
+++ b/internal/pkg/plugin/jiragithub/read.go
@@ -1,0 +1,36 @@
+package jiragithub
+
+import (
+	"github.com/merico-dev/stream/pkg/util/github"
+)
+
+// Read get jira-github-integ workflows.
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
+	opt, err := parseAndValidateOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	ghOptions := &github.Option{
+		Owner:    opt.Owner,
+		Repo:     opt.Repo,
+		NeedAuth: true,
+	}
+	ghClient, err := github.NewClient(ghOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := ghClient.GetWorkflowPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildReadState(path), nil
+}
+
+func BuildReadState(path string) map[string]interface{} {
+	res := make(map[string]interface{})
+	res["workflowDir"] = path
+	return res
+}

--- a/internal/pkg/plugin/jiragithub/render.go
+++ b/internal/pkg/plugin/jiragithub/render.go
@@ -1,0 +1,32 @@
+package jiragithub
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/mitchellh/mapstructure"
+
+	github "github.com/merico-dev/stream/pkg/util/github"
+)
+
+func renderTemplate(workflow *github.Workflow, options *Options) (string, error) {
+	var opts Options
+	err := mapstructure.Decode(options, &opts)
+	if err != nil {
+		return "", err
+	}
+
+	//if use default {{.}}, it will confict (github actions vars also use them)
+	t, err := template.New("jiragithub").Delims("[[", "]]").Parse(workflow.WorkflowContent)
+	if err != nil {
+		return "", err
+	}
+
+	var buff bytes.Buffer
+	err = t.Execute(&buff, opts)
+	if err != nil {
+		return "", err
+	}
+
+	return buff.String(), nil
+}

--- a/internal/pkg/plugin/jiragithub/templates.go
+++ b/internal/pkg/plugin/jiragithub/templates.go
@@ -1,0 +1,114 @@
+package jiragithub
+
+var jiraIssuesBuilder = `name: jira-github-integ Builder 
+on:
+  issues:
+    types: [opened, reopened, edited, closed]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  github-jira-issue:
+    name: Transition Issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@master
+      env:
+        JIRA_BASE_URL: [[.JiraBaseUrl]]
+        JIRA_USER_EMAIL: [[.JiraUserEmail]]
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+    - name: Create new Jira issue
+      id: create
+      if: ${{ github.event.action == 'opened' }}
+      uses: atlassian/gajira-create@master
+      with:
+        project: [[.JiraProjectKey]]
+        issuetype: Task
+        summary: ${{ github.event.issue.title }}
+        description: ${{ github.event.issue.body }}
+    
+    - name: Rename github issue
+      if: ${{ github.event.action == 'opened' }}
+      uses: actions-cool/issues-helper@v3
+      with:
+        actions: 'update-issue'
+        token: ${{ secrets.GH_TOKEN }}
+        issue-number: ${{ github.event.issue.number }}
+        state: 'open'
+        title: "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+        update-mode: 'replace'
+        emoji: '+1'
+      
+    - name: Find Jira Issue Key
+      id: find
+      if: ${{ github.event.action != 'opened' }}
+      uses: atlassian/gajira-find-issue-key@master
+      with:
+        string: "${{ github.event.issue.title }}"
+        
+    - name: Transition issue to In Progress
+      id: transition_inprogress
+      if: ${{ github.event.action == 'edited' }}
+      uses: atlassian/gajira-transition@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "In Progress"
+
+    - name: Transition issue to Done
+      id: transition_done
+      if: ${{ github.event.action == 'closed' }}
+      uses: atlassian/gajira-transition@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "Done"
+
+    - name: Transition issue to TO DO
+      id: transition_todo
+      if: ${{ github.event.action == 'reopened' }}
+      uses: atlassian/gajira-transition@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "To Do"
+    
+  issue_comment_integration:
+    if: ${{ github.event_name == 'issue_comment' }}
+    runs-on: ubuntu-latest
+    name: Integrate Issue Comment
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@master
+      env:
+        JIRA_BASE_URL: [[.JiraBaseUrl]]
+        JIRA_USER_EMAIL: [[.JiraUserEmail]]
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+    - name: Find Issue Key
+      id: find
+      uses: atlassian/gajira-find-issue-key@master
+      with:
+        string: "${{ github.event.issue.title }}"        
+    - name: Create issue
+      id: create_issue
+      if: ${{ github.event.action == 'created' }}
+      uses: atlassian/gajira-comment@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        comment: ${{ github.event.comment.body }}
+
+    - name: Edit issue
+      id: edit_issue
+      if: ${{ github.event.action == 'edited' }}
+      uses: atlassian/gajira-comment@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        comment: "updated: ${{ github.event.comment.body }} from: ${{ github.event.changes.body.from }}"
+        
+    - name: Delete issue
+      id: del_issue
+      if: ${{ github.event.action == 'deleted' }}
+      uses: atlassian/gajira-comment@master
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        comment: "deleted: ${{ github.event.comment.body }}"
+`

--- a/internal/pkg/plugin/jiragithub/update.go
+++ b/internal/pkg/plugin/jiragithub/update.go
@@ -1,0 +1,39 @@
+package jiragithub
+
+import (
+	"github.com/merico-dev/stream/pkg/util/github"
+)
+
+// Update remove and set up jira-github-integ workflows.
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
+	opt, err := parseAndValidateOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	ghOptions := &github.Option{
+		Owner:    opt.Owner,
+		Repo:     opt.Repo,
+		NeedAuth: true,
+	}
+	ghClient, err := github.NewClient(ghOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ghClient.DeleteWorkflow(workflow, opt.Branch); err != nil {
+		return nil, err
+	}
+
+	content, err := renderTemplate(workflow, opt)
+	if err != nil {
+		return nil, err
+	}
+	workflow.WorkflowContent = content
+
+	if err = ghClient.AddWorkflow(workflow, opt.Branch); err != nil {
+		return nil, err
+	}
+
+	return BuildState(opt.Owner, opt.Repo), nil
+}

--- a/internal/pkg/plugin/jiragithub/validation.go
+++ b/internal/pkg/plugin/jiragithub/validation.go
@@ -1,0 +1,21 @@
+package jiragithub
+
+import "fmt"
+
+// validate validates the options provided by the core.
+func validate(param *Options) []error {
+	retErrors := make([]error, 0)
+
+	// owner/repo/branch
+	if param.Owner == "" {
+		retErrors = append(retErrors, fmt.Errorf("owner is empty"))
+	}
+	if param.Repo == "" {
+		retErrors = append(retErrors, fmt.Errorf("repo is empty"))
+	}
+	if param.Branch == "" {
+		retErrors = append(retErrors, fmt.Errorf("branch is empty"))
+	}
+
+	return retErrors
+}

--- a/internal/pkg/plugin/jiragithub/workflow.go
+++ b/internal/pkg/plugin/jiragithub/workflow.go
@@ -1,0 +1,16 @@
+package jiragithub
+
+import (
+	github "github.com/merico-dev/stream/pkg/util/github"
+)
+
+const (
+	CommitMessage   = "jira-github-integ github actions workflow, created by DevStream"
+	BuilderFileName = "jira-github-integ.yml"
+)
+
+var workflow = &github.Workflow{
+	CommitMessage:    CommitMessage,
+	WorkflowFileName: BuilderFileName,
+	WorkflowContent:  jiraIssuesBuilder,
+}


### PR DESCRIPTION
# Summary

Add  jira-github-integ plugin

- when create a issue from github, it will be created in jira todo
-  when comment a issue from github, it will be commented in jira 
-  when edit a issue from github, it will be moved to in progress in jira 
-  when close a issue from github, it will be moved to done in jira 
-  when reopen a issue from github, it will be moved to todo in jira 



### Other Information

Any other information that is important to this PR.
