### PR TITLE
feat: dtm verify logic and logging improvement

### DIFF
--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -9,21 +9,17 @@ import (
 
 var verifyCMD = &cobra.Command{
 	Use:   "verify",
-	Short: "Verify DevOps tools according to DevStream configuration file",
-	Long:  `Verify DevOps tools according to DevStream configuration file.`,
+	Short: "Verify DevOps tools according to DevStream config file and state.",
+	Long:  `Verify DevOps tools according to DevStream config file and state.`,
 	Run:   verifyCMDFunc,
 }
 
 func verifyCMDFunc(cmd *cobra.Command, args []string) {
 	log.Info("Verify started.")
-	healthy, err := pluginengine.Verify(configFile)
-	if err != nil {
-		log.Fatalf("Verify error: %s.", err)
-	}
 
-	if healthy {
-		log.Success("All tools are healthy.")
+	if pluginengine.Verify(configFile) {
+		log.Success("Verify succeeded.")
 	} else {
-		log.Error("Some tools are NOT healthy!!!")
+		log.Info("Verify finished.")
 	}
 }

--- a/docs/commands_in_detail/verify.md
+++ b/docs/commands_in_detail/verify.md
@@ -1,0 +1,30 @@
+# `dtm verify` in Action
+
+The command `dtm verify` checks the following:
+
+## 1. Config File
+
+`dtm verify` first verifies if the config file can be loaded successfully.
+
+If not, the following information might be printed out:
+
+- if the config file doesn't exist, it reminds you if you forgot to specify the config file by using the "-f" parameter;
+- if the config format isn't correct, it would print some error.
+
+## 2. Plugins
+
+`dtm verify` then checks if all required plugins (according to the config file) exist.
+
+If not, it tries to give you a hint that maybe you forgot to run `dtm init` first.
+
+## 3. State
+
+`dtm verify` also tries to create a state manager that operates a backend. If something is wrong with the state, it generates an error telling you what exactly the error is.
+
+## 4. Config / State / Resource
+
+For definitions of _Config_, _State_, and _Resource_, see the [config_state_resource_explanation.md](../config_state_resource_explanation.md).
+
+`dtm verify` tries to see if the _Config_ matches the _State_ and the _Resource_ or not. If not, it tells you what exactly is not the same, and what would happen if you run `dtm apply`.
+
+If all the above checks are successful, `dtm verify` finishes with a success log "Verify succeeded."

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -55,8 +55,9 @@ func LoadConf(fname string) *Config {
 	fileBytes, err := ioutil.ReadFile(fname)
 	if err != nil {
 		log.Error(err)
-		log.Info("Perhaps you forgot to specify the path of the config file by using the \"-f\" parameter?")
-		log.Fatal("See more help by running \"dtm help\".")
+		log.Info("Maybe the default file doesn't exist or you forgot to pass your config file to the \"-f\" option?")
+		log.Info("See \"dtm help\" for more information.")
+		return nil
 	}
 
 	log.Debugf("Config file: \n%s\n", string(fileBytes))

--- a/internal/pkg/plugin/githubactions/golang/create.go
+++ b/internal/pkg/plugin/githubactions/golang/create.go
@@ -25,7 +25,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	// if docker is enabled, create repo secrets for DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
 	if opt.Docker.Enable {

--- a/internal/pkg/plugin/githubactions/golang/delete.go
+++ b/internal/pkg/plugin/githubactions/golang/delete.go
@@ -23,7 +23,7 @@ func Delete(options map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
-	log.Infof("language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("language is %s.", ga.GetLanguage(opt.Language))
 
 	// if docker is enabled, delete repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
 	if opt.Docker.Enable {

--- a/internal/pkg/plugin/githubactions/golang/read.go
+++ b/internal/pkg/plugin/githubactions/golang/read.go
@@ -27,7 +27,7 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	return ga.BuildReadState(path), nil
 }

--- a/internal/pkg/plugin/githubactions/golang/update.go
+++ b/internal/pkg/plugin/githubactions/golang/update.go
@@ -25,7 +25,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is %s.", ga.GetLanguage(opt.Language))
 
 	if opt.Docker.Enable {
 		for _, secret := range []string{"DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"} {

--- a/internal/pkg/plugin/githubactions/nodejs/create.go
+++ b/internal/pkg/plugin/githubactions/nodejs/create.go
@@ -23,7 +23,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	for _, w := range workflows {
 		if err := gitHubClient.AddWorkflow(w, opt.Branch); err != nil {

--- a/internal/pkg/plugin/githubactions/nodejs/delete.go
+++ b/internal/pkg/plugin/githubactions/nodejs/delete.go
@@ -23,7 +23,7 @@ func Delete(options map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
-	log.Infof("Language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is %s.", ga.GetLanguage(opt.Language))
 
 	for _, pipeline := range workflows {
 		err := gitHubClient.DeleteWorkflow(pipeline, opt.Branch)

--- a/internal/pkg/plugin/githubactions/nodejs/read.go
+++ b/internal/pkg/plugin/githubactions/nodejs/read.go
@@ -27,7 +27,7 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	return ga.BuildReadState(path), nil
 }

--- a/internal/pkg/plugin/githubactions/nodejs/update.go
+++ b/internal/pkg/plugin/githubactions/nodejs/update.go
@@ -23,7 +23,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("language is %s.", ga.GetLanguage(opt.Language))
 
 	for _, pipeline := range workflows {
 		err := gitHubClient.DeleteWorkflow(pipeline, opt.Branch)

--- a/internal/pkg/plugin/githubactions/python/create.go
+++ b/internal/pkg/plugin/githubactions/python/create.go
@@ -23,7 +23,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	for _, w := range workflows {
 		if err := gitHubClient.AddWorkflow(w, opt.Branch); err != nil {

--- a/internal/pkg/plugin/githubactions/python/delete.go
+++ b/internal/pkg/plugin/githubactions/python/delete.go
@@ -23,7 +23,7 @@ func Delete(options map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
-	log.Infof("Language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is %s.", ga.GetLanguage(opt.Language))
 
 	for _, pipeline := range workflows {
 		err := gitHubClient.DeleteWorkflow(pipeline, opt.Branch)

--- a/internal/pkg/plugin/githubactions/python/read.go
+++ b/internal/pkg/plugin/githubactions/python/read.go
@@ -27,7 +27,7 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is: %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	return ga.BuildReadState(path), nil
 }

--- a/internal/pkg/plugin/githubactions/python/update.go
+++ b/internal/pkg/plugin/githubactions/python/update.go
@@ -23,7 +23,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	log.Infof("Language is %s.", ga.GetLanguage(opt.Language))
+	log.Debugf("Language is %s.", ga.GetLanguage(opt.Language))
 
 	for _, pipeline := range workflows {
 		err := gitHubClient.DeleteWorkflow(pipeline, opt.Branch)

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -11,9 +11,10 @@ import (
 
 // Change is a wrapper with a single Tool and its Action should be execute.
 type Change struct {
-	Tool       *configloader.Tool
-	ActionName statemanager.ComponentAction
-	Result     *ChangeResult
+	Tool        *configloader.Tool
+	ActionName  statemanager.ComponentAction
+	Result      *ChangeResult
+	Description string
 }
 
 // ChangeResult holds the result with a change action.

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -95,6 +95,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 					changes = append(changes, generateUpdateAction(&tool, description))
 				} else {
 					// resource is the same as the state, do nothing
+					log.Debugf("Tool < %s > is the same as the state, do nothing.", tool.Name)
 				}
 			}
 		}

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -38,6 +38,9 @@ func Apply(configFile string, continueDirectly bool) error {
 		log.Info("No changes done since last apply. There is nothing to do.")
 		return nil
 	}
+	for _, change := range changes {
+		log.Info(change.Description)
+	}
 
 	if !continueDirectly {
 		userInput := readUserInput()

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -37,6 +37,9 @@ func Remove(configFile string, continueDirectly bool) error {
 		log.Info("Nothing needs to be deleted. There is nothing to do.")
 		return nil
 	}
+	for _, change := range changes {
+		log.Info(change.Description)
+	}
 
 	if !continueDirectly {
 		userInput := readUserInput()

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -25,7 +25,7 @@ func Verify(configFile string) bool {
 	// 3. can successfully create the state
 	smgr, err := statemanager.NewManager()
 	if err != nil {
-		log.Debugf("Failed to get the manager: %s.", err)
+		log.Errorf("Something is wrong with the state: %s.", err)
 		return false
 	}
 

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -1,45 +1,45 @@
 package pluginengine
 
 import (
-	"fmt"
-
 	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/pluginmanager"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
-// Verify returns true while all tools are healthy
-func Verify(configFile string) (bool, error) {
+// Verify returns true if all the comments in this function are met
+func Verify(configFile string) bool {
+	// 1. loading config file succeeded
 	cfg := configloader.LoadConf(configFile)
 	if cfg == nil {
-		return false, fmt.Errorf("failed to load the config file")
+		return false
 	}
 
+	// 2. according to the config, all needed plugins exist
 	err := pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {
-		log.Errorf("Error checking required plugins. Maybe you forgot to run \"dtm init\" first?")
-		return false, err
+		log.Info(err)
+		log.Info("Maybe you forgot to run \"dtm init\" first?")
+		return false
 	}
-
+	// 3. can successfully create the state
 	smgr, err := statemanager.NewManager()
 	if err != nil {
 		log.Debugf("Failed to get the manager: %s.", err)
-		return false, err
+		return false
 	}
 
+	// 4. if the config, state and the resources/tools are exactly the same
 	changes, err := GetChangesForApply(smgr, cfg)
 	if err != nil {
-		log.Debugf("Get changes for apply failed: %s.", err)
-		return false, err
+		log.Errorf("Get changes failed: %s.", err)
+		return false
 	}
-	if len(changes) == 0 {
-		log.Info("All plugins is healthy now.")
-		return true, nil
+	if len(changes) != 0 {
+		for _, change := range changes {
+			log.Info(change.Description)
+		}
+		return false
 	}
-
-	for _, c := range changes {
-		log.Infof("The plugin < %s > has been changed, need to %s.", c.Tool.Name, c.ActionName)
-	}
-	return false, nil
+	return true
 }

--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -49,7 +49,5 @@ func (c *Client) GetRepoDescription() (*github.Repository, error) {
 		return nil, errors.New("response status is not 200 OK, but is " + fmt.Sprintf("%d", resp.StatusCode))
 	}
 
-	log.Successf("GitHub repo exists, repo is %s, owner is %s.", *rps.Name, *rps.Owner.Login)
-
 	return rps, nil
 }


### PR DESCRIPTION
# Summary

1. dtm verify should not "fail" or "error" in any circumstances. The purpose of the "verify", as the word means, is to make sure if something is as expected.
2. The "error" in the log is a bit too much. If an "error" message is displayed, the user might think something went wrong or something they did is wrong, which isn't the case in the original post's issue.
3. we should have dedicated documentation explaining how everything works.

## Key Points

- [x] This is a breaking change.
- [x] Documentation (new or existing) is updated.

### Related Issues

Closes #255

Closes #252 

## Test Results

```bash
$ ./dtm verify
2022-03-03 11:03:15 ℹ [INFO]  Verify started.
2022-03-03 11:03:15 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-03 11:03:15 ℹ [INFO]  Tool < golang-demo-repo > found in config but doesn't exist in the state, will be created.
2022-03-03 11:03:15 ℹ [INFO]  Tool < golang-demo-app > found in config but doesn't exist in the state, will be created.
2022-03-03 11:03:15 ℹ [INFO]  Verify finished.
$ rm -rf .devstream/
$ ./dtm verify
2022-03-03 11:03:27 ℹ [INFO]  Verify started.
2022-03-03 11:03:27 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-03 11:03:27 ℹ [INFO]  stat .devstream/github-repo-scaffolding-golang-darwin-arm64_0.2.0.so: no such file or directory
2022-03-03 11:03:27 ℹ [INFO]  Maybe you forgot to run "dtm init" first?
2022-03-03 11:03:27 ℹ [INFO]  Verify finished.
```