### PR TITLE
feat: Terraform for AWS VPC/EKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ testbin/
 
 # plugins
 .github-*
+
+# terraform
+.terraform

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ testbin/
 
 # terraform
 .terraform
+

--- a/hack/terraform/.terraform.lock.hcl
+++ b/hack/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.3.0"
+  constraints = "4.3.0"
+  hashes = [
+    "h1:+/UcPbNhOmn+DIsiGugJd3B8ruKgXfC2JxIX9PCCFJI=",
+    "zh:087c67e5429f343a164221c05a83f152322f411e7394f8a39ed81a75982af1f2",
+    "zh:2e852a1b107e5324524874e1cd98bcf3a69284b4fe04750aa373054177c54214",
+    "zh:4b9a54b5895f945827832e6ddd16ff107301fedf47acbd83d17d4e18bbf10bb1",
+    "zh:64dfc02bc85f5df2f51ff942fc78d72fcd0db17b0f53e1fae380e58adbd239b3",
+    "zh:766f9aef619cfd23e924aee523791acccd30b6d8f1cc0ed1a7b5c953bf8c5392",
+    "zh:90048d87ff3071a4356cf91916b46a7ec69ba55bcba5765b598d3fe545d4c6ca",
+    "zh:c51f5b238af37c63e9033a12fd7fedc87c03eb966f5f5c7786eb6246e8bf3071",
+    "zh:d0df94d3112a25de609dfb55c5e3b0d119dea519a2bdd8099e64a8d63f22b683",
+    "zh:de166ecfeed70f570cea72ec094f00c2f997496b3226fa08518e7cd4a73884e1",
+    "zh:e31c31d00f42ea2dbaab1ad4c245da5cfff63e28399b5a5795b5e6a826c6c8af",
+    "zh:f93725afd8410194ede51d83505327aa1ae6a9b4280cf31db649c62c7dc203ae",
+  ]
+}

--- a/hack/terraform/config.tf
+++ b/hack/terraform/config.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.3.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "devstream-terraform-state"
+    key    = "test.tfstate"
+    region = "ap-southeast-1"
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-1"
+
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
+}

--- a/hack/terraform/main.tf
+++ b/hack/terraform/main.tf
@@ -1,0 +1,29 @@
+module "network" {
+  source = "./modules/networking"
+
+  vpc_name       = "DevStream"
+  vpc_cidr_block = "10.0.0.0/16"
+
+  public_subnets = {
+    "ap-southeast-1a" = "10.0.1.0/24"
+    "ap-southeast-1b" = "10.0.2.0/24"
+  }
+
+  private_subnets = {
+    "ap-southeast-1a" = "10.0.11.0/24"
+    "ap-southeast-1b" = "10.0.12.0/24"
+  }
+
+  team = "DevStream"
+}
+
+module "cluster" {
+  source = "./modules/eks"
+
+  cluster_name      = "dtm-test"
+  nodegroup_name    = "dtm-test-1"
+  vpc_id            = module.network.vpc_id
+  worker_subnet_ids = module.network.private_subnet_ids
+
+  team = "DevStream"
+}

--- a/hack/terraform/modules/eks/README.md
+++ b/hack/terraform/modules/eks/README.md
@@ -1,0 +1,3 @@
+# AWS EKS Module
+
+This module creates an EKS cluster with managed node group.

--- a/hack/terraform/modules/eks/cluster.tf
+++ b/hack/terraform/modules/eks/cluster.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "cluster" {
+  name        = "${var.cluster_name}_eks_cluster_sg"
+  description = "EKS cluster security group."
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.cluster_name}_eks_cluster_sg"
+    Team = var.team
+  }
+}
+
+resource "aws_security_group_rule" "cluster_egress_internet" {
+  description       = "Allow cluster egress access to the Internet."
+  protocol          = "-1"
+  security_group_id = aws_security_group.cluster.id
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "cluster_https_worker_ingress" {
+  description              = "Allow pods to communicate with the EKS cluster API."
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cluster.id
+  source_security_group_id = aws_security_group.worker.id
+  from_port                = 443
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_eks_cluster" "cluster" {
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.AmazonEKSServicePolicy,
+  ]
+  version  = var.k8s_version
+  name     = var.cluster_name
+  role_arn = aws_iam_role.eks_role.arn
+  vpc_config {
+    subnet_ids         = var.worker_subnet_ids
+    security_group_ids = [aws_security_group.cluster.id]
+  }
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
+  tags = {
+    Team = var.team
+  }
+}

--- a/hack/terraform/modules/eks/cluster_roles.tf
+++ b/hack/terraform/modules/eks/cluster_roles.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_role" "eks_role" {
+  name = "eks-cluster-${var.cluster_name}-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+
+  tags = {
+    Team = var.team
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.eks_role.name
+}

--- a/hack/terraform/modules/eks/control_plane_sg.tf
+++ b/hack/terraform/modules/eks/control_plane_sg.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "control_plane" {
+  name        = "eks_cluster_${var.cluster_name}_control_plane_sg"
+  description = "EKS cluster ${var.cluster_name} control plane security group."
+
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name = "eks_cluster_${var.cluster_name}_control_plane_sg"
+    Team = var.team
+
+  }
+}

--- a/hack/terraform/modules/eks/nodegroup.tf
+++ b/hack/terraform/modules/eks/nodegroup.tf
@@ -1,0 +1,24 @@
+resource "aws_eks_node_group" "default" {
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.eks_worker_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.eks_worker_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.eks_worker_autoscaling
+  ]
+
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = "${aws_eks_cluster.cluster.name}-managed-${var.nodegroup_name}"
+  node_role_arn   = aws_iam_role.worker_role.arn
+  subnet_ids      = var.worker_subnet_ids
+  instance_types  = [var.worker_instance_type]
+
+  scaling_config {
+    min_size     = var.min_worker_node_number
+    desired_size = var.desired_worker_node_number
+    max_size     = var.max_worker_node_number
+  }
+
+  tags = {
+    Team = var.team
+  }
+}

--- a/hack/terraform/modules/eks/output.tf
+++ b/hack/terraform/modules/eks/output.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  value = aws_eks_cluster.cluster.id
+}
+
+output "endpoint" {
+  value = aws_eks_cluster.cluster.endpoint
+}
+
+output "kubeconfig_certificate_authority_data" {
+  value = aws_eks_cluster.cluster.certificate_authority[0].data
+}
+
+output "security_group_id" {
+  value = aws_eks_cluster.cluster.vpc_config[0].cluster_security_group_id
+}
+
+output "worker_node_role_name" {
+  value = aws_iam_role.worker_role.name
+}

--- a/hack/terraform/modules/eks/variables.tf
+++ b/hack/terraform/modules/eks/variables.tf
@@ -1,0 +1,52 @@
+# mandatory variables
+
+# cluster
+variable "cluster_name" {
+  type = string
+}
+
+variable "nodegroup_name" {
+  type = string
+}
+
+# networking
+variable "vpc_id" {
+  description = "The existing VPC"
+}
+
+variable "worker_subnet_ids" {
+  type        = list(any)
+  description = "the subnets where to deploy EKS"
+}
+
+# optional variables
+variable "k8s_version" {
+  type    = string
+  default = "1.21"
+}
+
+variable "worker_instance_type" {
+  description = "worker type, like t2.medium"
+  type        = string
+  default     = "t2.medium"
+}
+
+variable "min_worker_node_number" {
+  type    = number
+  default = 2
+}
+
+variable "desired_worker_node_number" {
+  type    = number
+  default = 2
+}
+
+variable "max_worker_node_number" {
+  type    = number
+  default = 2
+}
+
+variable "team" {
+  type        = string
+  description = "used for tagging, to which team the resource belongs"
+}

--- a/hack/terraform/modules/eks/worker_node_roles.tf
+++ b/hack/terraform/modules/eks/worker_node_roles.tf
@@ -1,0 +1,87 @@
+resource "aws_iam_role" "worker_role" {
+  name = "eks-cluster-${var.cluster_name}-worker-node-role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+      }
+    ]
+}
+EOF
+
+  tags = {
+    Team = var.team
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.worker_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.worker_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.worker_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_autoscaling" {
+  policy_arn = aws_iam_policy.worker_autoscaling.arn
+  role       = aws_iam_role.worker_role.name
+}
+
+resource "aws_iam_policy" "worker_autoscaling" {
+  name_prefix = "eks-worker-autoscaling-${var.cluster_name}"
+  policy      = data.aws_iam_policy_document.worker_autoscaling.json
+  path        = "/"
+
+  tags = {
+    Team = var.team
+  }
+}
+
+data "aws_iam_policy_document" "worker_autoscaling" {
+  statement {
+    sid    = "eksWorkerAutoscalingAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "eksWorkerAutoscalingOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/hack/terraform/modules/eks/worker_node_sg.tf
+++ b/hack/terraform/modules/eks/worker_node_sg.tf
@@ -1,0 +1,55 @@
+resource "aws_security_group" "worker" {
+  name        = "${var.cluster_name}_eks_worker_node_sg"
+  description = "Security group for all nodes in the cluster."
+  vpc_id      = var.vpc_id
+
+  lifecycle {
+    ignore_changes = [ingress]
+  }
+
+  tags = {
+    Name                     = "${var.cluster_name}_eks_worker_node_sg"
+    "kubernetes.io/cluster/" = var.cluster_name
+    Team                     = var.team
+  }
+}
+
+resource "aws_security_group_rule" "workers_egress_internet" {
+  description       = "Allow nodes all egress to the Internet."
+  protocol          = "-1"
+  security_group_id = aws_security_group.worker.id
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "workers_ingress_self" {
+  description              = "Allow node to communicate with each other."
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.worker.id
+  from_port                = 0
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "workers_ingress_cluster" {
+  description              = "Allow workers pods to receive communication from the cluster control plane."
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.cluster.id
+  from_port                = 1025
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "workers_ingress_cluster_https" {
+  description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.cluster.id
+  from_port                = 443
+  to_port                  = 443
+  type                     = "ingress"
+}

--- a/hack/terraform/modules/networking/README.md
+++ b/hack/terraform/modules/networking/README.md
@@ -1,0 +1,10 @@
+# AWS VPC Module
+
+This module creates:
+
+- VPC
+- public subnets
+- private subnets
+- NAT gateways in each public subnet (including the EIP of course)
+- routing tables and associations (each private subnet routes to the NAT gateway in the same AZ)
+- Internet gateway

--- a/hack/terraform/modules/networking/gateway.tf
+++ b/hack/terraform/modules/networking/gateway.tf
@@ -1,0 +1,28 @@
+# internet gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+}
+
+# elastic IP for nat gateway
+resource "aws_eip" "nat_gateway" {
+  for_each = var.public_subnets
+
+  vpc = true
+
+  tags = {
+    Team = var.team
+  }
+}
+
+# nat gateway
+resource "aws_nat_gateway" "main" {
+  for_each = var.public_subnets
+
+  allocation_id = aws_eip.nat_gateway[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  tags = {
+    Team = var.team
+  }
+}

--- a/hack/terraform/modules/networking/output.tf
+++ b/hack/terraform/modules/networking/output.tf
@@ -1,0 +1,17 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "private_subnet_route_table_ids" {
+  value = [
+    for r in aws_route_table.private :
+    r.id
+  ]
+}
+
+output "private_subnet_ids" {
+  value = [
+    for r in aws_subnet.private :
+    r.id
+  ]
+}

--- a/hack/terraform/modules/networking/routing_table.tf
+++ b/hack/terraform/modules/networking/routing_table.tf
@@ -1,0 +1,41 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "public"
+    Team = var.team
+  }
+}
+
+resource "aws_route_table_association" "public_subnet" {
+  for_each = var.public_subnets
+
+  subnet_id      = aws_subnet.public[each.key].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  for_each = var.private_subnets
+
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[each.key].id
+  }
+
+  tags = {
+    Name = "private-${each.key}"
+    Team = var.team
+  }
+}
+
+resource "aws_route_table_association" "private_subnet" {
+  for_each = var.private_subnets
+
+  subnet_id      = aws_subnet.private[each.key].id
+  route_table_id = aws_route_table.private[each.key].id
+}

--- a/hack/terraform/modules/networking/subnet.tf
+++ b/hack/terraform/modules/networking/subnet.tf
@@ -1,0 +1,27 @@
+# public subnets
+resource "aws_subnet" "public" {
+  for_each = var.public_subnets
+
+  vpc_id            = aws_vpc.main.id
+  availability_zone = each.key
+  cidr_block        = each.value
+
+  tags = {
+    Name = "public-${each.key}"
+    Team = var.team
+  }
+}
+
+# private subnets
+resource "aws_subnet" "private" {
+  for_each = var.private_subnets
+
+  vpc_id            = aws_vpc.main.id
+  availability_zone = each.key
+  cidr_block        = each.value
+
+  tags = {
+    Name = "private-${each.key}"
+    Team = var.team
+  }
+}

--- a/hack/terraform/modules/networking/variables.tf
+++ b/hack/terraform/modules/networking/variables.tf
@@ -1,0 +1,32 @@
+variable "vpc_cidr_block" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "vpc_name" {
+  type    = string
+  default = "main"
+}
+
+variable "public_subnets" {
+  type = map(any)
+  default = {
+    "eu-central-1a" = "10.0.1.0/24"
+    "eu-central-1b" = "10.0.2.0/24"
+    "eu-central-1c" = "10.0.3.0/24"
+  }
+}
+
+variable "private_subnets" {
+  type = map(any)
+  default = {
+    "eu-central-1a" = "10.0.11.0/24"
+    "eu-central-1b" = "10.0.12.0/24"
+    "eu-central-1c" = "10.0.13.0/24"
+  }
+}
+
+variable "team" {
+  type        = string
+  description = "used for tagging, to which team the resource belongs"
+}

--- a/hack/terraform/modules/networking/vpc.tf
+++ b/hack/terraform/modules/networking/vpc.tf
@@ -1,0 +1,11 @@
+# creates vpc, default routing table, default security group and default network ACL
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = var.vpc_name
+    Team = var.team
+  }
+}


### PR DESCRIPTION
# Summary

## Description

This PR creates two Terraform modules, one is for AWS VPC (and networking related,) and the other is for AWS EKS.

The VPC module has been tested; due to cost issues, the EKS module hasn't been tested yet; it will be tested later when we need to run a DTM test.

Notes:
- Terraform uses a remote state (S3, bucket created manually).
- State-lock isn't implemented yet since we are a very small team so there is no need to bring in DynamoDB TF state lock yet.
