### PR TITLE
bug: GitHub Actions Plugin fails when Docker section doesn't exist

### DIFF
--- a/internal/pkg/plugin/githubactions/golang/create.go
+++ b/internal/pkg/plugin/githubactions/golang/create.go
@@ -28,7 +28,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	log.Debugf("Language is: %s.", ga.GetLanguage(opt.Language))
 
 	// if docker is enabled, create repo secrets for DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
-	if opt.Docker.Enable {
+	if opt.Docker != nil && opt.Docker.Enable {
 		if err := ghClient.AddRepoSecret("DOCKERHUB_USERNAME", viper.GetString("dockerhub_username")); err != nil {
 			return nil, err
 		}

--- a/internal/pkg/plugin/githubactions/golang/delete.go
+++ b/internal/pkg/plugin/githubactions/golang/delete.go
@@ -26,7 +26,7 @@ func Delete(options map[string]interface{}) (bool, error) {
 	log.Debugf("language is %s.", ga.GetLanguage(opt.Language))
 
 	// if docker is enabled, delete repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
-	if opt.Docker.Enable {
+	if opt.Docker != nil && opt.Docker.Enable {
 		for _, secret := range []string{"DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"} {
 			if err := ghClient.DeleteRepoSecret(secret); err != nil {
 				return false, err

--- a/internal/pkg/plugin/githubactions/golang/options.go
+++ b/internal/pkg/plugin/githubactions/golang/options.go
@@ -53,14 +53,5 @@ func validate(param *Options) []error {
 		}
 	}
 
-	if param.Docker == nil {
-		retErrors = append(retErrors, fmt.Errorf("docker is empty"))
-	}
-	if errs := param.Docker.Validate(); len(errs) != 0 {
-		for _, e := range errs {
-			retErrors = append(retErrors, fmt.Errorf("docker is invalid: %s", e))
-		}
-	}
-
 	return retErrors
 }

--- a/internal/pkg/plugin/githubactions/golang/options.go
+++ b/internal/pkg/plugin/githubactions/golang/options.go
@@ -53,5 +53,15 @@ func validate(param *Options) []error {
 		}
 	}
 
+	if param.Docker == nil {
+		return retErrors
+	}
+
+	if errs := param.Docker.Validate(); len(errs) != 0 {
+		for _, e := range errs {
+			retErrors = append(retErrors, fmt.Errorf("docker is invalid: %s", e))
+		}
+	}
+
 	return retErrors
 }

--- a/internal/pkg/plugin/githubactions/golang/render.go
+++ b/internal/pkg/plugin/githubactions/golang/render.go
@@ -15,8 +15,13 @@ func renderTemplate(workflow *github.Workflow, options *Options) (string, error)
 	if err != nil {
 		return "", err
 	}
+	// let Build is false when empty
 	if opts.Build == nil {
 		opts.Build = &Build{false, ""}
+	}
+	// let Docker is false when empty
+	if opts.Docker == nil {
+		opts.Docker = &Docker{false, ""}
 	}
 
 	//if use default {{.}}, it will confict (github actions vars also use them)

--- a/internal/pkg/plugin/githubactions/golang/update.go
+++ b/internal/pkg/plugin/githubactions/golang/update.go
@@ -27,7 +27,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 
 	log.Debugf("Language is %s.", ga.GetLanguage(opt.Language))
 
-	if opt.Docker.Enable {
+	if opt.Docker != nil && opt.Docker.Enable {
 		for _, secret := range []string{"DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"} {
 			if err := ghClient.DeleteRepoSecret(secret); err != nil {
 				return nil, err
@@ -47,6 +47,12 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		content, err := renderTemplate(pipeline, opt)
+		if err != nil {
+			return nil, err
+		}
+		pipeline.WorkflowContent = content
 
 		err = ghClient.AddWorkflow(pipeline, opt.Branch)
 		if err != nil {


### PR DESCRIPTION
# Summary

when docker section config is empty, dtm will raise errors
![image](https://user-images.githubusercontent.com/94163234/156697895-65aaab5a-df8d-4a67-a220-e443f2c685ba.png)


## Description
resolution
1. remove docker section validation
2. add if condition
3. when docker section is empty in render template, let it be false

### Related Issues

#264 
