### PR TITLE
feat: enable values.yaml feature for apps installed by helm

### DIFF
--- a/docs/plugins/argocd_plugin.md
+++ b/docs/plugins/argocd_plugin.md
@@ -34,6 +34,15 @@ tools:
       timeout: 5m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
+      # custom configuration (Optinal). You can refer to [argo-cd values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
+      values_yaml: |
+        controller:
+          service: 
+            port: 8080
+        redis:
+          image:
+            tag: 6.2.6-alpine3.15
+        
 ```
 
-Currently, all the parameters in the example above are mandatory.
+Except for `values_yaml`, all the parameters in the example above are mandatory.

--- a/pkg/util/helm/param.go
+++ b/pkg/util/helm/param.go
@@ -26,5 +26,5 @@ type Chart struct {
 	UpgradeCRDs     bool   `mapstructure:"upgradeCRDs"`
 	// ValuesYaml is the values.yaml content.
 	// use string instead of map[string]interface{}
-	ValuesYaml string
+	ValuesYaml string `mapstructure:"values_yaml"`
 }


### PR DESCRIPTION

# Summary

feat: enable values.yaml feature for apps installed by helm


## Key Points

- [x] Documentation (new or existing) is updated.

## Description

The following is `test.yaml`. I want to install argocd in k8s and change the redis image version to 6.2.6-alpine3.15 and controller service's port to 8080 by `values_yaml` field in `test.yaml`.

```yaml
tools:
- name: argocd
  plugin:
    # name of the plugin
    kind: argocd
    # version of the plugin
    version: 0.2.0
  options:
    # need to create the namespace or not, default: false
    create_namespace: true
    repo:
      # name of the Helm repo
      name: argo
      # url of the Helm repo
      url: https://argoproj.github.io/argo-helm
    # Helm chart information
    chart:
      # name of the chart
      chart_name: argo/argo-cd
      # release name of the chart
      release_name: argocd
      # k8s namespace where argocd will be installed
      namespace: argocd
      # whether to wait for the release to be deployed or not
      wait: true
      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
      timeout: 10m
      # whether to perform a CRD upgrade during installation
      upgradeCRDs: true
      # custom configuration (Optinal). You can refer to [argo-cd values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
      values_yaml: |
        controller:
          service: 
            port: 8080
        redis:
          image:
            tag: 6.2.6-alpine3.15
        
```

```yaml
✅ 😁 ./dtm-darwin-arm64 apply -f test.yaml 
2022-03-04 21:39:54 ℹ [INFO]  Apply started.
2022-03-04 21:39:54 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-04 21:39:54 ℹ [INFO]  Tool < argocd > found in config but doesn't exist in the state, will be created.
Continue? [y/n]
Enter a value (Default is n): y

2022-03-04 21:39:56 ℹ [INFO]  Start executing the plan.
2022-03-04 21:39:56 ℹ [INFO]  Changes count: 1.
2022-03-04 21:39:56 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-04 21:39:56 ℹ [INFO]  Processing: argocd -> Create ...
2022-03-04 21:39:59 ℹ [INFO]  Creating or updating argocd helm chart ...
2022/03/04 21:40:02 creating 1 resource(s)
2022/03/04 21:40:02 CRD applications.argoproj.io is already present. Skipping.
2022/03/04 21:40:02 creating 1 resource(s)
2022/03/04 21:40:02 CRD argocdextensions.argoproj.io is already present. Skipping.
2022/03/04 21:40:02 creating 1 resource(s)
2022/03/04 21:40:02 CRD appprojects.argoproj.io is already present. Skipping.
2022/03/04 21:40:05 creating 29 resource(s)
2022/03/04 21:40:05 beginning wait for 29 resources with timeout of 10m0s
2022/03/04 21:40:05 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:07 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:09 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:11 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:13 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:15 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:17 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:19 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:21 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:23 Deployment is not ready: argocd/argocd-application-controller. 0 out of 1 expected pods are ready
2022/03/04 21:40:26 release installed successfully: argocd/argo-cd-3.35.0
2022-03-04 21:40:26 ✔ [SUCCESS]  Plugin argocd Create done.
2022-03-04 21:40:26 ✔ [SUCCESS]  All plugins applied successfully.
2022-03-04 21:40:26 ✔ [SUCCESS]  Apply finished
```

<img width="729" alt="image" src="https://user-images.githubusercontent.com/16207029/156781954-f9433580-aac6-484c-97b2-7a96b08fd244.png">

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/16207029/156781834-d60c8134-3a91-4d53-880d-a70def271853.png">



### Related Issues

#272 

