### PR TITLE
ci: support `doc` type in commit message

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -9,3 +9,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
+        with:
+          configFile: ${{ github.workspace }}/build/ci/commitlint.config.js

--- a/build/ci/commitlint.config.js
+++ b/build/ci/commitlint.config.js
@@ -1,0 +1,31 @@
+const Configuration = {
+    /*
+     * Resolve and load @commitlint/config-conventional from node_modules.
+     * Referenced packages must be installed
+     */
+    extends: ['@commitlint/config-conventional'],
+    
+    rules: {
+        'type-enum': [
+              2,
+              'always',
+              [
+                  'build',
+                  'chore',
+                  'ci',
+                  'docs',
+                  'doc',
+                  'feat',
+                  'fix',
+                  'perf',
+                  'refactor',
+                  'revert',
+                  'style',
+                  'test',
+              ],
+        ],
+    },
+   
+  };
+  
+  module.exports = Configuration;


### PR DESCRIPTION

# Summary

- add `commitlint.config.js` for commit lint tool to support `doc` type in commit message

## Description

Default commit lint doesn't support `doc` type, however somebody may be used to using `doc` instead of `docs`, I hope it is acceptable.

### Current Behavior

When you use `doc` type in commit message, the commit-lint stage can't pass

### New Behavior

Both `doc` and `docs` are allowed

### Screenshots

<img width="509" alt="image" src="https://user-images.githubusercontent.com/16207029/156876913-35818952-b20b-4378-80cf-e533cac6a45d.png">

