### PR TITLE
feat!: no longer configure default values for Jenkins values.yaml in the code

### DIFF
--- a/docs/plugins/argocd_plugin.md
+++ b/docs/plugins/argocd_plugin.md
@@ -26,7 +26,7 @@ tools:
       chart_name: argo/argo-cd
       # release name of the chart
       release_name: argocd
-      # k8s namespace where argocd will be installed
+      # k8s namespace where ArgoCD will be installed
       namespace: argocd
       # whether to wait for the release to be deployed or not
       wait: true
@@ -34,7 +34,7 @@ tools:
       timeout: 5m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
-      # custom configuration (Optinal). You can refer to [argo-cd values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
+      # custom configuration (Optional). You can refer to [ArgoCD values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
       values_yaml: |
         controller:
           service: 
@@ -42,7 +42,7 @@ tools:
         redis:
           image:
             tag: 6.2.6-alpine3.15
-        
+
 ```
 
-Except for `values_yaml`, all the parameters in the example above are mandatory.
+Currently, except for `values_yaml`, all the parameters in the example above are mandatory.

--- a/docs/plugins/jenkins_plugin.md
+++ b/docs/plugins/jenkins_plugin.md
@@ -46,6 +46,14 @@ tools:
       timeout: 5m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
+      # custom configuration (Optional). You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
+      values_yaml: |
+        persistence:
+          storageClass: jenkins-pv
+        serviceAccount:
+          create: false
+          name: jenkins
+
 ```
 
 Currently, all the parameters in the example above are mandatory.

--- a/docs/plugins/kube-prometheus_plugin.md
+++ b/docs/plugins/kube-prometheus_plugin.md
@@ -37,6 +37,10 @@ tools:
       timeout: 5m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
+      # custom configuration (Optional). You can refer to [kube-prometheus-stack values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
+      values_yaml: |
+        namespaceOverride: "monitoring"
+
 ```
 
-Currently, all the parameters in the example above are mandatory.
+Currently, except for `values_yaml`, all the parameters in the example above are mandatory.

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -24,8 +24,6 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("params are illegal")
 	}
 
-	renderValuesYamlForJenkins(&param)
-
 	if err := DealWithNsWhenInstall(&param); err != nil {
 		return nil, err
 	}
@@ -69,13 +67,4 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	log.Debugf("Return map: %v.", retMap)
 
 	return retMap, nil
-}
-
-func renderValuesYamlForJenkins(param *Param) {
-	param.Chart.ValuesYaml = `persistence:
-  storageClass: jenkins-pv
-serviceAccount:
-  create: false
-  name: jenkins
-`
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Now we have opened the customize `values.yaml` function , so the logic with `values.yaml` of `Jenkins` needs to be modified accordingly.

See the issue/pr below for more info.

#272 #274 