### PR TITLE
refactor: using `util/github` in `trellogithub`

### DIFF
--- a/internal/pkg/plugin/trellogithub/create.go
+++ b/internal/pkg/plugin/trellogithub/create.go
@@ -6,34 +6,34 @@ import (
 
 // Create sets up trello-github-integ workflows.
 func Create(options map[string]interface{}) (map[string]interface{}, error) {
-	gis, err := NewTrelloGithub(options)
+	tg, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err
 	}
 
-	api := gis.GetApi()
+	api := tg.GetApi()
 	log.Infof("API is: %s.", api.Name)
 	ws := defaultWorkflows.GetWorkflowByNameVersionTypeString(api.Name)
 
 	for _, w := range ws {
-		if err := gis.renderTemplate(w); err != nil {
+		if err := tg.renderTemplate(w); err != nil {
 			return nil, err
 		}
-		if err := gis.AddWorkflow(w); err != nil {
+		if err := tg.client.AddWorkflow(w, tg.options.Branch); err != nil {
 			return nil, err
 		}
 	}
 	log.Success("Adding workflow file succeeded.")
-	trelloIds, err := gis.CreateTrelloItems()
+	trelloIds, err := tg.CreateTrelloItems()
 	if err != nil {
 		return nil, err
 	}
 	log.Success("Creating trello board succeeded.")
-	if err := gis.AddTrelloIdSecret(trelloIds); err != nil {
+	if err := tg.AddTrelloIdSecret(trelloIds); err != nil {
 		return nil, err
 	}
 
 	log.Success("Adding secret keys for trello succeeded.")
 
-	return buildState(gis, trelloIds), nil
+	return buildState(tg, trelloIds), nil
 }

--- a/internal/pkg/plugin/trellogithub/delete.go
+++ b/internal/pkg/plugin/trellogithub/delete.go
@@ -6,17 +6,17 @@ import (
 
 // Delete remove trello-github-integ workflows.
 func Delete(options map[string]interface{}) (bool, error) {
-	gis, err := NewTrelloGithub(options)
+	tg, err := NewTrelloGithub(options)
 	if err != nil {
 		return false, err
 	}
 
-	api := gis.GetApi()
+	api := tg.GetApi()
 	log.Infof("API is %s.", api.Name)
 	ws := defaultWorkflows.GetWorkflowByNameVersionTypeString(api.Name)
 
 	for _, w := range ws {
-		err := gis.DeleteWorkflow(w)
+		err := tg.client.DeleteWorkflow(w, tg.options.Branch)
 		if err != nil {
 			return false, err
 		}

--- a/internal/pkg/plugin/trellogithub/helper.go
+++ b/internal/pkg/plugin/trellogithub/helper.go
@@ -3,55 +3,24 @@ package trellogithub
 import (
 	"bytes"
 	"fmt"
-	"net/http"
-	"strings"
+
 	"text/template"
 
-	"github.com/google/go-github/v42/github"
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/merico-dev/stream/pkg/util/github"
 	"github.com/merico-dev/stream/pkg/util/trello"
 )
 
-// getFileSHA will try to collect the SHA hash value of the file, then return it. the return values will be:
-// 1. If file exists without error -> string(SHA), nil
-// 2. If some errors occurred -> return "", err
-// 3. If file not found without error -> return "", nil
-func (gi *TrelloGithub) getFileSHA(filename string) (string, error) {
-	content, _, resp, err := gi.client.Repositories.GetContents(
-		gi.ctx,
-		gi.options.Owner,
-		gi.options.Repo,
-		generateGitHubWorkflowFileByName(filename),
-		&github.RepositoryContentGetOptions{},
-	)
-
-	// error reason is not 404
-	if err != nil && !strings.Contains(err.Error(), "404") {
-		return "", err
-	}
-
-	// error reason is 404
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
-	}
-
-	// no error occurred
-	if resp.StatusCode == http.StatusOK {
-		return *content.SHA, nil
-	}
-	return "", fmt.Errorf("got some error")
-}
-
 // renderTemplate render the github actions template with config.yaml
-func (gi *TrelloGithub) renderTemplate(workflow *Workflow) error {
+func (tg *TrelloGithub) renderTemplate(workflow *github.Workflow) error {
 	var jobs Jobs
-	err := mapstructure.Decode(gi.options.Jobs, &jobs)
+	err := mapstructure.Decode(tg.options.Jobs, &jobs)
 	if err != nil {
 		return err
 	}
 	//if use default {{.}}, it will confict (github actions vars also use them)
-	t, err := template.New("trellogithub").Delims("[[", "]]").Parse(workflow.workflowContent)
+	t, err := template.New("trellogithub").Delims("[[", "]]").Parse(workflow.WorkflowContent)
 	if err != nil {
 		return err
 	}
@@ -61,7 +30,7 @@ func (gi *TrelloGithub) renderTemplate(workflow *Workflow) error {
 	if err != nil {
 		return err
 	}
-	workflow.workflowContent = buff.String()
+	workflow.WorkflowContent = buff.String()
 	return nil
 }
 
@@ -75,24 +44,20 @@ func buildState(tg *TrelloGithub, ti *TrelloItemId) map[string]interface{} {
 	return res
 }
 
-func (gi *TrelloGithub) buildReadState(api *Api) (map[string]interface{}, error) {
+func (tg *TrelloGithub) buildReadState(api *Api) (map[string]interface{}, error) {
 	c, err := trello.NewClient()
 	if err != nil {
 		return nil, err
 	}
-	listIds, err := c.GetBoardIdAndListId(gi.options.Owner, gi.options.Repo, api.KanbanBoardName)
+	listIds, err := c.GetBoardIdAndListId(tg.options.Owner, tg.options.Repo, api.KanbanBoardName)
 	if err != nil {
 		return nil, err
 	}
 
-	path, err := gi.GetWorkflowPath()
+	path, err := tg.GetWorkflowPath()
 	if err != nil {
 		return nil, err
 	}
 	listIds["workflowDir"] = path
 	return listIds, nil
-}
-
-func generateGitHubWorkflowFileByName(f string) string {
-	return fmt.Sprintf(".github/workflows/%s", f)
 }

--- a/internal/pkg/plugin/trellogithub/read.go
+++ b/internal/pkg/plugin/trellogithub/read.go
@@ -5,16 +5,16 @@ import (
 )
 
 func Read(options map[string]interface{}) (map[string]interface{}, error) {
-	gis, err := NewTrelloGithub(options)
+	tg, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err
 	}
 
-	api := gis.GetApi()
+	api := tg.GetApi()
 	log.Infof("API is: %s.", api.Name)
 
 	ws := defaultWorkflows.GetWorkflowByNameVersionTypeString(api.Name)
-	retMap, err := gis.VerifyWorkflows(ws)
+	retMap, err := tg.VerifyWorkflows(ws)
 	if err != nil {
 		return nil, err
 	}
@@ -31,5 +31,5 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, nil
 	}
 
-	return gis.buildReadState(api)
+	return tg.buildReadState(api)
 }

--- a/internal/pkg/plugin/trellogithub/trellogithub.go
+++ b/internal/pkg/plugin/trellogithub/trellogithub.go
@@ -59,12 +59,12 @@ func NewTrelloGithub(options map[string]interface{}) (*TrelloGithub, error) {
 	}, nil
 }
 
-func (gi *TrelloGithub) GetApi() *Api {
-	return gi.options.Api
+func (tg *TrelloGithub) GetApi() *Api {
+	return tg.options.Api
 }
 
 // CompareFiles compare files between local and remote
-func (gi *TrelloGithub) CompareFiles(wsFiles, filesInRemoteDir []string) map[string]error {
+func (tg *TrelloGithub) CompareFiles(wsFiles, filesInRemoteDir []string) map[string]error {
 	lostFiles := slicez.SliceInSliceStr(wsFiles, filesInRemoteDir)
 	// all files exist
 	if len(lostFiles) == 0 {
@@ -83,13 +83,13 @@ func (gi *TrelloGithub) CompareFiles(wsFiles, filesInRemoteDir []string) map[str
 
 // CreateTrelloItems create board/lists, and set secret by ids
 // TODO(daniel-hutao): rename the function name
-func (gi *TrelloGithub) CreateTrelloItems() (*TrelloItemId, error) {
+func (tg *TrelloGithub) CreateTrelloItems() (*TrelloItemId, error) {
 	c, err := trello.NewClient()
 	if err != nil {
 		return nil, err
 	}
 
-	board, err := c.CreateBoard(gi.options.Api.KanbanBoardName, gi.options.Owner, gi.options.Repo)
+	board, err := c.CreateBoard(tg.options.Api.KanbanBoardName, tg.options.Owner, tg.options.Repo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/trellogithub/update.go
+++ b/internal/pkg/plugin/trellogithub/update.go
@@ -6,40 +6,40 @@ import (
 
 // Update remove and set up trello-github-integ workflows.
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
-	gis, err := NewTrelloGithub(options)
+	tg, err := NewTrelloGithub(options)
 	if err != nil {
 		return nil, err
 	}
 
-	api := gis.GetApi()
+	api := tg.GetApi()
 	log.Infof("API is %s.", api.Name)
 	ws := defaultWorkflows.GetWorkflowByNameVersionTypeString(api.Name)
 
 	for _, w := range ws {
-		err := gis.DeleteWorkflow(w)
+		err := tg.client.DeleteWorkflow(w, tg.options.Branch)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := gis.renderTemplate(w); err != nil {
+		if err := tg.renderTemplate(w); err != nil {
 			return nil, err
 		}
-		err = gis.AddWorkflow(w)
+		err = tg.client.AddWorkflow(w, tg.options.Branch)
 		if err != nil {
 			return nil, err
 		}
 	}
 	log.Success("Adding workflow file succeeded.")
-	trelloIds, err := gis.CreateTrelloItems()
+	trelloIds, err := tg.CreateTrelloItems()
 	if err != nil {
 		return nil, err
 	}
 	log.Success("Creating trello board succeeded.")
-	if err := gis.AddTrelloIdSecret(trelloIds); err != nil {
+	if err := tg.AddTrelloIdSecret(trelloIds); err != nil {
 		return nil, err
 	}
 
 	log.Success("Adding secret keys for trello succeeded.")
 
-	return buildState(gis, trelloIds), nil
+	return buildState(tg, trelloIds), nil
 }

--- a/internal/pkg/plugin/trellogithub/workflow.go
+++ b/internal/pkg/plugin/trellogithub/workflow.go
@@ -2,6 +2,7 @@ package trellogithub
 
 import (
 	"github.com/merico-dev/stream/internal/pkg/plugin/trellogithub/trello"
+	"github.com/merico-dev/stream/pkg/util/github"
 )
 
 const (
@@ -15,7 +16,11 @@ var extTrello = &Api{
 
 var defaultWorkflows = workflows{
 	extTrello.Name: {
-		{defaultCommitMessage, BuilderYmlTrello, trello.IssuesBuilder},
+		{
+			CommitMessage:    defaultCommitMessage,
+			WorkflowFileName: BuilderYmlTrello,
+			WorkflowContent:  trello.IssuesBuilder,
+		},
 	},
 }
 
@@ -33,18 +38,9 @@ type Api struct {
 	KanbanBoardName string
 }
 
-// Workflow is the struct for a GitHub Actions Workflow.
-type Workflow struct {
-	commitMessage    string
-	workflowFileName string
-	workflowContent  string
-}
+type workflows map[string][]*github.Workflow
 
-type ToolString string
-
-type workflows map[string][]*Workflow
-
-func (ws *workflows) GetWorkflowByNameVersionTypeString(nvtStr string) []*Workflow {
+func (ws *workflows) GetWorkflowByNameVersionTypeString(nvtStr string) []*github.Workflow {
 	workflowList, exist := (*ws)[nvtStr]
 	if exist {
 		return workflowList


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

There are many functions in the `trellogithub` package that are duplicated in `util/github`, so we can delete these functions and directly refer to `util/github`.

But there are still some functions that are not implemented in `util/github`, so part of the functions is not easy to refactor for now. Later we need to spend some time for letting the `trellogithub` without any line of code directly use the `"github.com/google/go-github/v42/github"`.