### PR TITLE
refactor: use type StateKey for the key of `state`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean: ## Remove local plugins and locally built artifacts.
 	rm -f dtm*
 	rm -rf build/working_dir
 
-build-linux-amd64: ## Cross-platform build for linux/amd64
+build-linux-amd64: ## Cross-platform build for "linux/amd64".
 	echo "Building in ${BUILD_PATH}"
 	mkdir -p .devstream
 	rm -rf ${BUILD_PATH} && mkdir ${BUILD_PATH}
@@ -61,8 +61,8 @@ e2e: build ## Run e2e tests.
 	./dtm-${GOOS}-${GOARCH} verify -f config.yaml
 	./dtm-${GOOS}-${GOARCH} delete -f config.yaml
 
-e2e-up: ## Start kind cluster for e2e tests
+e2e-up: ## Start kind cluster for e2e tests.
 	sh hack/e2e/e2e-up.sh
 
-e2e-down: ## Stop kind cluster for e2e tests
+e2e-down: ## Stop kind cluster for e2e tests.
 	sh hack/e2e/e2e-down.sh

--- a/README.md
+++ b/README.md
@@ -178,12 +178,13 @@ Usage:
   help                Display this help.
   build               Build dtm & plugins locally.
   build-core          Build dtm core only, without plugins, locally.
-  build-linux-amd64   Cross-platform build for linux/amd64
+  clean               Remove local plugins and locally built artifacts.
+  build-linux-amd64   Cross-platform build for "linux/amd64".
   fmt                 Run 'go fmt' & goimports against code.
   vet                 Run go vet against code.
   e2e                 Run e2e tests.
-  e2e-up              Start kind cluster for e2e tests
-  e2e-down            Stop kind cluster for e2e tests
+  e2e-up              Start kind cluster for e2e tests.
+  e2e-down            Stop kind cluster for e2e tests.
 ```
 
 #### Test

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -143,7 +143,7 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 	}
 
 	if change.ActionName == statemanager.ActionDelete {
-		key := getStateKeyFromTool(change.Tool)
+		key := statemanager.StateKeyGenerateFunc(change.Tool)
 		log.Infof("Prepare to delete '%s' from States.", key)
 		err := smgr.DeleteState(key)
 		if err != nil {
@@ -154,7 +154,7 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 		return nil
 	}
 
-	key := getStateKeyFromTool(change.Tool)
+	key := statemanager.StateKeyGenerateFunc(change.Tool)
 	state := statemanager.State{
 		Name:     change.Tool.Name,
 		Plugin:   change.Tool.Plugin,

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -64,7 +64,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 
 	// 2, for each tool in the config, generate changes.
 	for _, tool := range cfg.Tools {
-		state := smgr.GetState(getStateKeyFromTool(&tool))
+		state := smgr.GetState(statemanager.StateKeyGenerateFunc(&tool))
 
 		if state == nil {
 			// tool not in the state, create, no need to Read resource before Create
@@ -101,7 +101,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 		}
 
 		// delete the tool from the temporary state map since it's already been processed above
-		tmpStatesMap.Delete(getStateKeyFromTool(&tool))
+		tmpStatesMap.Delete(statemanager.StateKeyGenerateFunc(&tool))
 	}
 
 	// what's left in the temporary state map "tmpStatesMap" contains tools that:
@@ -125,13 +125,13 @@ func changesForDelete(smgr statemanager.Manager, cfg *configloader.Config) []*Ch
 	// reverse loop, a hack to solve dependency issues when deleting
 	for i := len(cfg.Tools) - 1; i >= 0; i-- {
 		tool := cfg.Tools[i]
-		state := smgr.GetState(getStateKeyFromTool(&tool))
+		state := smgr.GetState(statemanager.StateKeyGenerateFunc(&tool))
 		if state == nil {
 			continue
 		}
 		description := fmt.Sprintf("Tool < %s > will be deleted.", tool.Name)
 		changes = append(changes, generateDeleteAction(&tool, description))
-		tmpStates.Delete(tool.Name)
+		tmpStates.Delete(statemanager.StateKeyGenerateFunc(&tool))
 	}
 
 	return changes
@@ -147,8 +147,8 @@ func changesForForceDelete(smgr statemanager.Manager, cfg *configloader.Config) 
 		tool := cfg.Tools[i]
 		description := fmt.Sprintf("Tool < %s > will be deleted.", tool.Name)
 		changes = append(changes, generateDeleteAction(&tool, description))
-		if err := smgr.DeleteState(getStateKeyFromTool(&tool)); err != nil {
-			log.Errorf("Failed to delete %s from state.", getStateKeyFromTool(&tool))
+		if err := smgr.DeleteState(statemanager.StateKeyGenerateFunc(&tool)); err != nil {
+			log.Errorf("Failed to delete %s from state.", statemanager.StateKeyGenerateFunc(&tool))
 			return make([]*Change, 0)
 		}
 	}

--- a/internal/pkg/pluginengine/helper.go
+++ b/internal/pkg/pluginengine/helper.go
@@ -6,13 +6,8 @@ import (
 
 	"github.com/tcnksm/go-input"
 
-	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
-
-func getStateKeyFromTool(t *configloader.Tool) string {
-	return fmt.Sprintf("%s_%s", t.Name, t.Plugin.Kind)
-}
 
 func readUserInput() string {
 	ui := &input.UI{

--- a/internal/pkg/pluginengine/pluginengine_test.go
+++ b/internal/pkg/pluginengine/pluginengine_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Pluginengine", func() {
 			Tools: []configloader.Tool{*getTool(name, kind, version)},
 		}
 
-		err = smgr.AddState(fmt.Sprintf("%s_%s", name, kind), statemanager.State{})
+		err = smgr.AddState(statemanager.StateKey(fmt.Sprintf("%s_%s", name, kind)), statemanager.State{})
 		Expect(err).NotTo(HaveOccurred())
 		changes, _ := pluginengine.GetChangesForDelete(smgr, cfg, false)
 

--- a/internal/pkg/statemanager/manager.go
+++ b/internal/pkg/statemanager/manager.go
@@ -24,10 +24,10 @@ type Manager interface {
 
 	GetStatesMap() StatesMap
 
-	GetState(key string) *State
-	AddState(key string, state State) error
-	UpdateState(key string, state State) error
-	DeleteState(key string) error
+	GetState(key StateKey) *State
+	AddState(key StateKey, state State) error
+	UpdateState(key StateKey, state State) error
+	DeleteState(key StateKey) error
 }
 
 // manager is the default implement with Manager
@@ -64,7 +64,7 @@ func NewManager() (Manager, error) {
 		return nil, err
 	}
 
-	tmpMap := make(map[string]State)
+	tmpMap := make(map[StateKey]State)
 	if err = yaml.Unmarshal(data, tmpMap); err != nil {
 		log.Errorf("Failed to unmarshal the state file < %s >. error: %s.", local.DefaultStateFile, err)
 		log.Errorf("Reading the state file failed, it might have been compromised/modified by someone other than DTM.")
@@ -83,7 +83,7 @@ func (m *manager) GetStatesMap() StatesMap {
 	return m.statesMap
 }
 
-func (m *manager) GetState(key string) *State {
+func (m *manager) GetState(key StateKey) *State {
 	m.statesMap.Load(key)
 	if s, exist := m.statesMap.Load(key); exist {
 		state, _ := s.(State)
@@ -92,17 +92,17 @@ func (m *manager) GetState(key string) *State {
 	return nil
 }
 
-func (m *manager) AddState(key string, state State) error {
+func (m *manager) AddState(key StateKey, state State) error {
 	m.statesMap.Store(key, state)
 	return m.Write(m.GetStatesMap().Format())
 }
 
-func (m *manager) UpdateState(key string, state State) error {
+func (m *manager) UpdateState(key StateKey, state State) error {
 	m.statesMap.Store(key, state)
 	return m.Write(m.GetStatesMap().Format())
 }
 
-func (m *manager) DeleteState(key string) error {
+func (m *manager) DeleteState(key StateKey) error {
 	m.statesMap.Delete(key)
 	return m.Write(m.GetStatesMap().Format())
 }

--- a/internal/pkg/statemanager/manager_test.go
+++ b/internal/pkg/statemanager/manager_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Statemanager", func() {
 		})
 
 		It("Should get the state right", func() {
-			key := "name_githubactions"
+			key := statemanager.StateKey("name_githubactions")
 			stateA := statemanager.State{
 				Name:     "name",
 				Plugin:   configloader.Plugin{Kind: "githubactions", Version: "0.0.2"},

--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -2,6 +2,7 @@ package statemanager
 
 import (
 	"bytes"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 
@@ -24,7 +25,7 @@ type StatesMap struct {
 
 func NewStatesMap() StatesMap {
 	return StatesMap{
-		ConcurrentMap: concurrentmap.NewConcurrentMap("", State{}),
+		ConcurrentMap: concurrentmap.NewConcurrentMap(StateKey(""), State{}),
 	}
 }
 
@@ -38,9 +39,9 @@ func (s StatesMap) DeepCopy() StatesMap {
 }
 
 func (s StatesMap) Format() []byte {
-	tmpMap := make(map[string]State)
+	tmpMap := make(map[StateKey]State)
 	s.Range(func(key, value interface{}) bool {
-		tmpMap[key.(string)] = value.(State)
+		tmpMap[key.(StateKey)] = value.(State)
 		return true
 	})
 
@@ -58,4 +59,11 @@ func (s StatesMap) Format() []byte {
 	}
 
 	return buf.Bytes()
+}
+
+// Note: Please use the StateKeyGenerateFunc function to generate StateKey instance.
+type StateKey string
+
+func StateKeyGenerateFunc(t *configloader.Tool) StateKey {
+	return StateKey(fmt.Sprintf("%s_%s", t.Name, t.Plugin.Kind))
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

refactor: use type StateKey for the key of `state`

## Description

Since the format of the key with `state` is not randomly generated(we used a `name_kind` format), we need a `keyFunc` to generate this key.

Therefore, avoiding the use of the basic type `string` can make developers pay attention NOT to use a `casual string` as a key, but to call the corresponding `keyFunc` to generate it.

We've inadvertently fallen into the "string" trap more than once, such as:

1. #282

![image](https://user-images.githubusercontent.com/18692628/157033347-44e7b613-841f-4353-81a0-44dbae84d0e8.png)


2. #285

![image](https://user-images.githubusercontent.com/18692628/157033166-8613a8d4-7c8f-4044-a8e8-762114b5de82.png)

So I think it is more "robust" to use the `StateKey` type as the state key.

- statemanager/state.go 64

```go
// Note: Please use the StateKeyGenerateFunc function to generate StateKey instance.
type StateKey string
```