### PR TITLE
fix: print log stack when debug

### DIFF
--- a/pkg/util/log/logwrapper.go
+++ b/pkg/util/log/logwrapper.go
@@ -44,7 +44,7 @@ func (m *CliLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	timestamp := entry.Time.Format("2006-01-02 15:04:05")
 
-	if m.level == logrus.ErrorLevel {
+	if m.level == logrus.ErrorLevel && logrus.GetLevel() == logrus.DebugLevel {
 		entry.Message = addCallStackIgnoreLogrus(entry.Message)
 	}
 


### PR DESCRIPTION
# Summary

print log stacktrace only when log level is debug

if  you still want to print error stack, use "--debug" option, or it will not print stack

### Current Behavior

![image](https://user-images.githubusercontent.com/94163234/157634637-5dbdb3e2-8dc6-427e-9190-92db97e71abd.png)


### New Behavior

![image](https://user-images.githubusercontent.com/94163234/157634689-24f93dcf-bd52-4107-bb62-46bec74ea25b.png)

