### PR TITLE
fix: panic for `nil pointer dereference` in util/github

### DIFF
--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -42,6 +42,10 @@ func (c *Client) GetRepoDescription() (*github.Repository, error) {
 		c.Owner,
 		c.Repo)
 
+	if err != nil {
+		return nil, err
+	}
+
 	if repo == nil && resp.StatusCode == http.StatusNotFound {
 		return repo, nil
 	}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

fix: panic for `nil pointer dereference` in util/github

### Related Issues

close #302 