### PR TITLE
feat: support setting kubeconfig from env

### DIFF
--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -57,6 +57,9 @@ func initConfig() {
 	if err := viper.BindEnv("github_token"); err != nil {
 		log.Fatal(err)
 	}
+	if err := viper.BindEnv("kubeconfig"); err != nil {
+		log.Fatal(err)
+	}
 	if err := viper.BindEnv("dockerhub_username"); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/util/github/github.go
+++ b/pkg/util/github/github.go
@@ -66,6 +66,7 @@ func NewClient(option *Option) (*Client, error) {
 
 	// b. client with auth enabled
 
+	// TL;DR: Don't use viper.GetString("xxx") in the `util/xxx` package.
 	// Don't use `token := viper.GetString("github_token")` here,
 	// it will fail without calling `viper.BindEnv("github_token")` first.
 	// os.Getenv() function is more clear and reasonable here.


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

Support setting kubeconfig from env

## Description

To support running e2e tests in `GitHub actions`, `dtm` needs to be able to get `kubeconfig` from a "non-default" address(eg: /github/home/.kube/config in the eks action base image).

Perhaps it is not the most appropriate to configure this `kubeconfig path` by `environment variables`. But at present our `config.yaml` is all about plugin-related configuration, no core-related. So I made a compromise and implemented it in this way first.

Later, if necessary, I will add this type(non-secret) of configuration to config.yaml, that is, when we determine that `config.yaml` needs to contain the non-secret configuration of `dtm-core`