### PR TITLE
feat: add outputs for github repo scaffolding plugin

### DIFF
--- a/docs/plugins/argocdapp_plugin.md
+++ b/docs/plugins/argocdapp_plugin.md
@@ -1,9 +1,9 @@
 ## 1 `argocdapp` Plugin
 
-This plugin creates an ArgoCD Application.
+This plugin creates an [ArgoCD Application](https://argo-cd.readthedocs.io/en/stable/core_concepts/) custom resource.
 
 **Notes:**
-- ArgoCD itself must have been already installed before the usage of this plugin. To install ArgoCD, use [this plugin](https://github.com/merico-dev/stream/blob/main/docs/argocd_plugin.md).
+- ArgoCD itself must have been already installed before the usage of this plugin. To install ArgoCD, use the [argocd plugin](https://github.com/merico-dev/stream/blob/main/docs/argocd_plugin.md).
 - Currently, only the Helm chart is supported when creating the ArgoCD application.
 - At the moment, DevStream doesn't support dependency or concurrency yet. So, in the config file, the ArgoCD app plugin must be placed _after_ the ArgoCD plugin if you want to install ArgoCD first then create the ArgoCD application.
 
@@ -22,13 +22,13 @@ tools:
   dependsOn: [ "TOOL1_NAME.TOOL1_KIND", "TOOL2_NAME.TOOL2_KIND" ]
   # options for the plugin
   options:
-    # information on the ArgoCD application
+    # information on the ArgoCD Application
     app:
-      # name of the ArgoCD application
+      # name of the ArgoCD Application
       name: hello
-      # where the ArgoCD application CRD will be created
+      # where the ArgoCD Application custom resource will be created
       namespace: argocd
-    # destination of the application
+    # destination of the ArgoCD Application
     destination:
       # on which server to deploy
       server: https://kubernetes.default.svc
@@ -43,3 +43,51 @@ tools:
       # Helm chart repo URL, this is only an example, do not use this
       repoURL: https://github.com/ironcore864/openstream-gitops-test.git
 ```
+
+## 3. Use Together with the `github-repo-scaffolding-golang` Plugin
+
+This plugin can be used together with the `github-repo-scaffolding-golang` plugin (see document [here](./github-repo-scaffolding-golang_plugin.md).)
+
+For example, you can first use `github-repo-scaffolding-golang` to bootstrap a Golang repo, then use this plugin to set up basic GitHub Actions CI workflows. In this scenario:
+
+- This plugin can specify `github-repo-scaffolding-golang` as a dependency, so that the dependency is first satisfied before executing this plugin.
+- This plugin can refer to `github-repo-scaffolding-golang`'s output to reduce copy/paste human error.
+
+See the example below:
+
+```yaml
+---
+tools:
+- name: go-webapp-repo
+  plugin:
+    kind: github-repo-scaffolding-golang
+    version: 0.2.0
+  options:
+    owner: IronCore864
+    repo: go-webapp-devstream-demo
+    branch: main
+    image_repo: ironcore864/go-webapp-devstream-demo
+- name: go-webapp-argocd-deploy
+  plugin:
+    kind: argocdapp
+    version: 0.2.0
+  dependsOn: ["go-webapp-repo.github-repo-scaffolding-golang"]
+  options:
+    app:
+      name: hello
+      namespace: argocd
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: charts/go-hello-http
+      repoURL: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repoURL}}
+```
+
+In the example above:
+
+- We put `go-webapp-repo.github-repo-scaffolding-golang` as dependency by using the `dependsOn` keyword.
+- We used `go-webapp-repo.github-repo-scaffolding-golang`'s output as input for the `githubactions-golang` plugin.
+
+Pay attention to the `${{ xxx }}` part in the example. `${{ TOOL_NAME.TOOL_KIND.outputs.var}}` is the syntax for using an output.

--- a/docs/plugins/github-repo-scaffolding-golang_plugin.md
+++ b/docs/plugins/github-repo-scaffolding-golang_plugin.md
@@ -1,6 +1,6 @@
 ## 1 `github-repo-scaffolding-golang` Plugin
 
-This plugin installs github-repo-scaffolding-golang.
+This plugin bootstraps a GitHub repo with scaffolding code for a Golang web application.
 
 _This plugin depends on the following environment variable:_
 
@@ -11,13 +11,13 @@ Set it before using this plugin.
 If you don't know how to create this token, check out:
 - [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
-***Tips:***
+*Tips:*
 
-*1. if uninstall, the repo on github will be completely removed*
+*1. If you run `dtm delete`, the repo on GitHub will be completely removed.*
 
-*2. if reinstall，the repo on github will be completely removed and recreated*
+*2. If the `Update` interface is called, the repo on github will be completely removed and recreated. However, given our current implementation, this interface shall not be called, as of in v0.2.0.*
 
-## 2 Usage:
+## 2 Usage
 
 **Please note that the `owner` parameter is case-sensitive.**
 
@@ -43,4 +43,59 @@ tools:
     image_repo: YOUR_DOCKERHUB_USERNAME/YOUR_DOCKERHUB_IMAGE_REPO_NAME
 ```
 
+Replace the following from the config above:
+
+- `YOUR_GITHUB_USERNAME`
+- `YOUR_REPO_NAME`
+- `YOUR_DOCKERHUB_USERNAME`
+- `YOUR_DOCKERHUB_IMAGE_REPO_NAME`
+
+The "branch" in the example above is "main", but you can adjust accordingly.
+
 Currently, all the parameters in the example above are mandatory.
+
+## 3. Outputs
+
+This plugin has three outputs:
+
+- `owner`
+- `repo`
+- `repoURL` (example: "https://github.com/IronCore864/test.git")
+
+If, for example, you want to use the outputs as inputs for another plugin, you can refer to the following example:
+
+```yaml
+---
+tools:
+- name: go-webapp-repo
+  plugin:
+    kind: github-repo-scaffolding-golang
+    version: 0.2.0
+  options:
+    owner: IronCore864
+    repo: go-webapp-devstream-demo
+    branch: main
+    image_repo: ironcore864/go-webapp-devstream-demo
+- name: golang-demo-actions
+  plugin:
+    kind: githubactions-golang
+    version: 0.2.0
+  dependsOn: ["go-webapp-repo.github-repo-scaffolding-golang"]
+  options:
+    owner: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.owner}}
+    repo: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
+    language:
+      name: go
+      version: "1.17"
+    branch: main
+    build:
+      enable: True
+    test:
+      enable: True
+      coverage:
+        enable: True
+    docker:
+      enable: False
+```
+
+Pay attention to the `${{ xxx }}` part in the example. `${{ TOOL_NAME.TOOL_KIND.outputs.var}}` is the syntax for using an output.

--- a/docs/plugins/githubactions-golang_plugin.md
+++ b/docs/plugins/githubactions-golang_plugin.md
@@ -2,7 +2,7 @@
 
 This plugin creates some Golang GitHub Actions workflows.
 
-## 2 Usage:
+## 2 Usage
 
 _This plugin depends on the following environment variable:_
 
@@ -65,3 +65,55 @@ tools:
 ```
 
 Some parameters are optional. See the default values and optional parameters in the example above.
+
+## 3. Use Together with the `github-repo-scaffolding-golang` Plugin
+
+This plugin can be used together with the `github-repo-scaffolding-golang` plugin (see document [here](./github-repo-scaffolding-golang_plugin.md).)
+
+For example, you can first use `github-repo-scaffolding-golang` to bootstrap a Golang repo, then use this plugin to set up basic GitHub Actions CI workflows. In this scenario:
+
+- This plugin can specify `github-repo-scaffolding-golang` as a dependency, so that the dependency is first satisfied before executing this plugin.
+- This plugin can refer to `github-repo-scaffolding-golang`'s output to reduce copy/paste human error.
+
+See the example below:
+
+```yaml
+---
+tools:
+- name: go-webapp-repo
+  plugin:
+    kind: github-repo-scaffolding-golang
+    version: 0.2.0
+  options:
+    owner: IronCore864
+    repo: go-webapp-devstream-demo
+    branch: main
+    image_repo: ironcore864/go-webapp-devstream-demo
+- name: golang-demo-actions
+  plugin:
+    kind: githubactions-golang
+    version: 0.2.0
+  dependsOn: ["go-webapp-repo.github-repo-scaffolding-golang"]
+  options:
+    owner: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.owner}}
+    repo: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
+    language:
+      name: go
+      version: "1.17"
+    branch: main
+    build:
+      enable: True
+    test:
+      enable: True
+      coverage:
+        enable: True
+    docker:
+      enable: False
+```
+
+In the example above:
+
+- We put `go-webapp-repo.github-repo-scaffolding-golang` as dependency by using the `dependsOn` keyword.
+- We used `go-webapp-repo.github-repo-scaffolding-golang`'s output as input for the `githubactions-golang` plugin.
+
+Pay attention to the `${{ xxx }}` part in the example. `${{ TOOL_NAME.TOOL_KIND.outputs.var}}` is the syntax for using an output.

--- a/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
@@ -204,6 +204,13 @@ func buildState(param *Param) map[string]interface{} {
 	res := make(map[string]interface{})
 	res["owner"] = param.Owner
 	res["repoName"] = param.Repo
+
+	outputs := make(map[string]interface{})
+	outputs["owner"] = param.Owner
+	outputs["repo"] = param.Repo
+	outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", param.Owner, param.Repo)
+	res["outputs"] = outputs
+
 	return res
 }
 

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -50,5 +50,12 @@ func buildReadState(param *Param) (map[string]interface{}, error) {
 	res["owner"] = *repo.Owner.Login
 	res["repoName"] = *repo.Name
 
+	outputs := make(map[string]interface{})
+	outputs["owner"] = param.Owner
+	outputs["repo"] = param.Repo
+	outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", param.Owner, param.Repo)
+
+	res["outputs"] = outputs
+
 	return res, nil
 }

--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -23,7 +23,7 @@ func (c *Client) CreateRepo() error {
 
 func (c *Client) DeleteRepo() error {
 	response, err := c.Client.Repositories.Delete(c.Context, c.Owner, c.Repo)
-	
+
 	// error reason is not 404
 	if err != nil && !strings.Contains(err.Error(), "404") {
 		log.Errorf("Delete repo failed: %s.", err)


### PR DESCRIPTION
# Summary

- docs update for argocdapp/github scaffolding/github actions plugin
- add outputs for github actions plugin
- backwards compatible/non-breaking change (tested, state/core not affected by added output)

## Key Points

- [x] Documentation (new or existing) is updated.
