### PR TITLE
doc: adding `kind` in the log msg

### DIFF
--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -90,7 +90,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 
 	for i, c := range changes {
 		log.Separatorf("Processing progress: %d/%d.", i+1, numOfChanges)
-		log.Infof("Processing: %s -> %s ...", c.Tool.Name, c.ActionName)
+		log.Infof("Processing: %s(kind: %s) -> %s ...", c.Tool.Name, c.Tool.Plugin.Kind, c.ActionName)
 
 		var succeeded bool
 		var err error
@@ -138,8 +138,8 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 	}()
 
 	if !change.Result.Succeeded {
-		log.Errorf("Plugin %s %s failed.", change.Tool.Name, change.ActionName)
-		return fmt.Errorf("plugin %s %s failed", change.Tool.Name, change.ActionName)
+		log.Errorf("The tool < %s/%s > %s failed.", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
+		return fmt.Errorf("the tool < %s/%s > %s failed", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
 	}
 
 	if change.ActionName == statemanager.ActionDelete {
@@ -150,7 +150,7 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 			log.Debugf("Failed to delete state %s: %s.", key, err)
 			return err
 		}
-		log.Successf("Plugin %s delete done.", change.Tool.Name)
+		log.Successf("Plugin %s/%s delete done.", change.Tool.Name, change.Tool.Plugin.Kind)
 		return nil
 	}
 
@@ -166,6 +166,6 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 		log.Debugf("Failed to add state %s: %s.", key, err)
 		return err
 	}
-	log.Successf("Plugin %s %s done.", change.Tool.Name, change.ActionName)
+	log.Successf("Plugin %s(%s) %s done.", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

When the user names different plugin instances as `demo-x` , the absence of `kind` information will make the logs very `hard to read`.