### PR TITLE
feat: `dtm develop create-plugin` implement

### DIFF
--- a/cmd/devstream/develop.go
+++ b/cmd/devstream/develop.go
@@ -26,8 +26,8 @@ func developCMDFunc(cmd *cobra.Command, args []string) {
 	}
 
 	developAction := develop.Action(args[0])
-	log.Debugf("The develop action is: %s", developAction)
-	if err := develop.BranchAction(developAction); err != nil {
+	log.Debugf("The develop action is: %s.", developAction)
+	if err := develop.ExecuteAction(developAction); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/devstream/develop.go
+++ b/cmd/devstream/develop.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/merico-dev/stream/internal/pkg/develop"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+var name string
+
+var developCMD = &cobra.Command{
+	Use:   "develop",
+	Short: "Develop is used for develop a new plugin",
+	Long: `Develop is used for develop a new plugin.
+eg.
+- dtm develop create-plugin --name=YOUR-PLUGIN-NAME`,
+	Run: developCMDFunc,
+}
+
+func developCMDFunc(cmd *cobra.Command, args []string) {
+	if err := validateArgs(args); err != nil {
+		log.Fatal(err)
+	}
+
+	developAction := develop.Action(args[0])
+	log.Debugf("The develop action is: %s", developAction)
+	if err := develop.BranchAction(developAction); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func validateArgs(args []string) error {
+	// "create-plugin"/ maybe it will be "delete-plugin"/"rename-plugin" in future.
+	if len(args) != 1 {
+		return fmt.Errorf("got illegal args count (expect 1, got %d). "+
+			"See `help` command for more info", len(args))
+	}
+	developAction := develop.Action(args[0])
+	if !develop.IsValideAction(developAction) {
+		return fmt.Errorf("invalide Develop Action")
+	}
+	return nil
+}
+
+func init() {
+	developCMD.PersistentFlags().StringVarP(&name, "name", "n", "", "specify name with the new plugin")
+}

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -50,6 +50,7 @@ func init() {
 	rootCMD.AddCommand(deleteCMD)
 	rootCMD.AddCommand(destroyCMD)
 	rootCMD.AddCommand(verifyCMD)
+	rootCMD.AddCommand(developCMD)
 }
 
 func initConfig() {
@@ -73,6 +74,9 @@ func initConfig() {
 		log.Fatal(err)
 	}
 	if err := viper.BindPFlags(rootCMD.Flags()); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlags(developCMD.Flags()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/pkg/develop/develop.go
+++ b/internal/pkg/develop/develop.go
@@ -20,10 +20,10 @@ func IsValideAction(action Action) bool {
 	return ok
 }
 
-func BranchAction(action Action) error {
+func ExecuteAction(action Action) error {
 	switch action {
 	case ActionCreatePlugin:
-		log.Debugf("Action: %s", ActionCreatePlugin)
+		log.Debugf("Action: %s.", ActionCreatePlugin)
 		return plugin.Create()
 	default:
 		panic("This should be never happen!")

--- a/internal/pkg/develop/develop.go
+++ b/internal/pkg/develop/develop.go
@@ -1,0 +1,31 @@
+package develop
+
+import (
+	"github.com/merico-dev/stream/internal/pkg/develop/plugin"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+type Action string
+
+const (
+	ActionCreatePlugin Action = "create-plugin"
+)
+
+var ActionSet = map[Action]struct{}{
+	ActionCreatePlugin: {},
+}
+
+func IsValideAction(action Action) bool {
+	_, ok := ActionSet[action]
+	return ok
+}
+
+func BranchAction(action Action) error {
+	switch action {
+	case ActionCreatePlugin:
+		log.Debugf("Action: %s", ActionCreatePlugin)
+		return plugin.Create()
+	default:
+		panic("This should be never happen!")
+	}
+}

--- a/internal/pkg/develop/plugin/create.go
+++ b/internal/pkg/develop/plugin/create.go
@@ -1,0 +1,42 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+// Create creates a new plugin.
+// 1. Render template files
+// 2. Persist all files
+// 3. Print help information
+func Create() error {
+	name := viper.GetString("name")
+	if name == "" {
+		return fmt.Errorf("the name must be not \"\", you can specify it by --name flag")
+	}
+	log.Debugf("Got the name: %s.", name)
+
+	p := NewPlugin(name)
+
+	// 1. Render template files
+	files, err := p.RenderTplFiles()
+	if err != nil {
+		log.Debugf("Failed to render template files: %s.", err)
+		return err
+	}
+	log.Info("Render template files finished.")
+
+	// 2. Persist all files
+	if err := p.PersistFiles(files); err != nil {
+		log.Debugf("Failed to persist files: %s.", err)
+	}
+	log.Info("Persist all files finished.")
+
+	// 3. Print help information
+	p.PrintHelpInfo()
+
+	return nil
+}

--- a/internal/pkg/develop/plugin/plugin.go
+++ b/internal/pkg/develop/plugin/plugin.go
@@ -96,9 +96,9 @@ func (p *Plugin) PersistFiles(files []pluginTpl.File) error {
 	fileCount := len(files)
 	log.Debugf("There are %d files wait to persist.", fileCount)
 	for i, file := range files {
-		log.Debugf("Persist process: %d/%d", i+1, fileCount)
+		log.Debugf("Persist process: %d/%d.", i+1, fileCount)
 		if err := p.persistFile(&file); err != nil {
-			log.Errorf("Failed to persist: %s/%s", file.Dir, file.Name)
+			log.Errorf("Failed to persist: %s/%s.", file.Dir, file.Name)
 			return err
 		}
 	}

--- a/internal/pkg/develop/plugin/plugin.go
+++ b/internal/pkg/develop/plugin/plugin.go
@@ -1,0 +1,146 @@
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+	"text/template"
+
+	pluginTpl "github.com/merico-dev/stream/internal/pkg/develop/plugin/template"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+type Plugin struct {
+	Name string
+}
+
+func NewPlugin(name string) *Plugin {
+	return &Plugin{
+		Name: name,
+	}
+}
+
+// RenderTplFiles takes specified data that the templates needed,
+// then render TplFiles to "Files" and return it as []File.
+func (p *Plugin) RenderTplFiles() ([]pluginTpl.File, error) {
+	retFiles := make([]pluginTpl.File, 0)
+	count := len(pluginTpl.TplFiles)
+	log.Debugf("Template files count: %d.", count)
+
+	for i, tplFile := range pluginTpl.TplFiles {
+		log.Debugf("Render process: %d/%d.", i+1, count)
+		file, err := p.renderTplFile(&tplFile)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugf("File: %v.", *file)
+		retFiles = append(retFiles, *file)
+	}
+
+	return retFiles, nil
+}
+
+// RenderTplFile takes specified data that the template needed,
+// then render one TplFile to File and return it.
+func (p *Plugin) renderTplFile(tplFile *pluginTpl.TplFile) (*pluginTpl.File, error) {
+	name, err := p.renderTplString(tplFile.NameTpl)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := p.renderTplString(tplFile.DirTpl)
+	if err != nil {
+		return nil, err
+	}
+	content, err := p.renderTplString(tplFile.ContentTpl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pluginTpl.File{
+		Name:    name,
+		Dir:     dir,
+		Content: content,
+	}, nil
+}
+
+// renderTplString get the template string and the data object,
+// then render it and return the rendered string.
+func (p *Plugin) renderTplString(tplStr string) (string, error) {
+	if tplStr == "" {
+		return "", nil
+	}
+
+	t, err := template.New("default").Parse(tplStr)
+	if err != nil {
+		log.Debugf("Template parse failed: %s.", err)
+		log.Debugf("Template content: %s.", tplStr)
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, *p)
+	if err != nil {
+		log.Debugf("Template execute failed: %s.", err)
+		log.Debugf("Template content: %s.", tplStr)
+		log.Debugf("Data object: %v.", *p)
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// PersistFiles gets the []pluginTpl.File, for each File:
+// call the persistFile() method to deal with.
+func (p *Plugin) PersistFiles(files []pluginTpl.File) error {
+	fileCount := len(files)
+	log.Debugf("There are %d files wait to persist.", fileCount)
+	for i, file := range files {
+		log.Debugf("Persist process: %d/%d", i+1, fileCount)
+		if err := p.persistFile(&file); err != nil {
+			log.Errorf("Failed to persist: %s/%s", file.Dir, file.Name)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// persistFile gets the *pluginTpl.File, then do the following:
+// 1. mkdir the File.Dir
+// 2. create the File.Name file
+// 3. write the File.Content into the File.Name file
+func (p *Plugin) persistFile(file *pluginTpl.File) error {
+	// mkdir the File.Dir
+	if err := os.MkdirAll(file.Dir, 0755); err != nil {
+		log.Debugf("Failed to create directory: %s.", file.Dir)
+	}
+	log.Debugf("Directory created: %s.", file.Dir)
+
+	// create the File.Name file and write the File.Content into the File.Name file
+	filePath := path.Join(file.Dir, file.Name)
+	if err := os.WriteFile(filePath, []byte(file.Content), 0644); err != nil {
+		log.Debugf("Failed to write content to the file: %s.", err)
+	}
+	log.Debugf("File %s has been created.", filePath)
+
+	return nil
+}
+
+func (p *Plugin) PrintHelpInfo() {
+	help := `
+The DevStream PMC (project management committee) sincerely thank you for your devotion and enthusiasm in creating new plugins!
+
+To make the process easy as a breeze, DevStream(dtm) has generated some templated source code files for you to flatten the learning curve and reduce manual copy-paste.
+In the generated templates, dtm has left some special marks in the format of "TODO(dtm)".
+Please look for these TODOs by global search. Once you find them, you will know what to do with them. Also, please remember to check our documentation on creating a new plugin:
+
+**README_when_create_plugin.md**
+
+Source code files created.
+
+Happy hacking, buddy!
+Please give us feedback through GitHub issues if you encounter any difficulties. We guarantee that you will receive unrivaled help from our passionate community!
+`
+	fmt.Println(help)
+}

--- a/internal/pkg/develop/plugin/template/NAME.go
+++ b/internal/pkg/develop/plugin/template/NAME.go
@@ -1,0 +1,16 @@
+package template
+
+var NAME_go_nameTpl = "{{ .Name }}.go"
+var NAME_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var NAME_go_contentTpl = `package {{ .Name }}
+
+// TODO(dtm): Add your logic here.
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    NAME_go_nameTpl,
+		DirTpl:     NAME_go_dirTpl,
+		ContentTpl: NAME_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/NAME_plugin.md.go
+++ b/internal/pkg/develop/plugin/template/NAME_plugin.md.go
@@ -1,0 +1,18 @@
+package template
+
+var NAME_plugin_md_nameTpl = "{{ .Name }}_plugin.md"
+var NAME_plugin_md_dirTpl = "docs/plugins/plugin/"
+
+// TODO(daniel-hutao): * -> `
+var NAME_plugin_md_contentTpl = `## 1 *{{ .Name }}* Plugin
+
+// TODO(dtm): Add your document here.
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    NAME_plugin_md_nameTpl,
+		DirTpl:     NAME_plugin_md_dirTpl,
+		ContentTpl: NAME_plugin_md_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/README_when_create_plugin.md.go
+++ b/internal/pkg/develop/plugin/template/README_when_create_plugin.md.go
@@ -1,0 +1,23 @@
+package template
+
+var README_when_create_plugin_md_nameTpl = "README_when_create_plugin.md"
+var README_when_create_plugin_md_dirTpl = "./"
+var README_when_create_plugin_md_contentTpl = `# Note with **dtm develop create-plugin**
+
+## Done-Done Check
+
+- [ ] I've finished all the TODO items and deleted all the *TODO(dtm)* comments.
+
+The files below have been updated with my plugin:
+
+- [ ] Makefile
+- [ ] build/package/build_linux_amd64.sh
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    README_when_create_plugin_md_nameTpl,
+		DirTpl:     README_when_create_plugin_md_dirTpl,
+		ContentTpl: README_when_create_plugin_md_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/create.go
+++ b/internal/pkg/develop/plugin/template/create.go
@@ -1,0 +1,20 @@
+package template
+
+var create_go_nameTpl = "create.go"
+var create_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var create_go_contentTpl = `package {{ .Name }}
+
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
+    // TODO(dtm): Add your logic here.
+
+    return nil, nil
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    create_go_nameTpl,
+		DirTpl:     create_go_dirTpl,
+		ContentTpl: create_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/delete.go
+++ b/internal/pkg/develop/plugin/template/delete.go
@@ -1,0 +1,20 @@
+package template
+
+var delete_go_nameTpl = "delete.go"
+var delete_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var delete_go_contentTpl = `package {{ .Name }}
+
+func Delete(options map[string]interface{}) (bool, error) {
+    // TODO(dtm): Add your logic here.
+
+    return false, nil
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    delete_go_nameTpl,
+		DirTpl:     delete_go_dirTpl,
+		ContentTpl: delete_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/main.go
+++ b/internal/pkg/develop/plugin/template/main.go
@@ -1,0 +1,52 @@
+package template
+
+var main_go_nameTpl = "main.go"
+var main_go_dirTpl = "cmd/{{ .Name }}/"
+var main_go_contentTpl = `package main
+
+import (
+	"github.com/merico-dev/stream/internal/pkg/plugin/{{ .Name }}"
+	"github.com/merico-dev/stream/pkg/util/log"
+)
+
+// NAME is the name of this DevStream plugin.
+const NAME = "{{ .Name }}"
+
+// Plugin is the type used by DevStream core. It's a string.
+type Plugin string
+
+// Create implements the create of {{ .Name }}.
+func (p Plugin) Create(params map[string]interface{}) (map[string]interface{}, error) {
+	return {{ .Name }}.Create(params)
+}
+
+// Update implements the update of {{ .Name }}.
+func (p Plugin) Update(params map[string]interface{}) (map[string]interface{}, error) {
+	return {{ .Name }}.Update(params)
+}
+
+// Delete implements the delete of {{ .Name }}.
+func (p Plugin) Delete(params map[string]interface{}) (bool, error) {
+	return {{ .Name }}.Delete(params)
+}
+
+// Read implements the read of {{ .Name }}.
+func (p Plugin) Read(params map[string]interface{}) (map[string]interface{}, error) {
+	return {{ .Name }}.Read(params)
+}
+
+// DevStreamPlugin is the exported variable used by the DevStream core.
+var DevStreamPlugin Plugin
+
+func main() {
+	log.Infof("%T: %s is a plugin for DevStream. Use it with DevStream.\n", NAME, DevStreamPlugin)
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    main_go_nameTpl,
+		DirTpl:     main_go_dirTpl,
+		ContentTpl: main_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/options.go
+++ b/internal/pkg/develop/plugin/template/options.go
@@ -1,0 +1,20 @@
+package template
+
+var options_go_nameTpl = "options.go"
+var options_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var options_go_contentTpl = `package {{ .Name }}
+
+// Options is the struct for configurations of the {{ .Name }} plugin.
+type Options struct {
+    // TODO(dtm): Add your params here.
+	Foo string
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    options_go_nameTpl,
+		DirTpl:     options_go_dirTpl,
+		ContentTpl: options_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/read.go
+++ b/internal/pkg/develop/plugin/template/read.go
@@ -1,0 +1,20 @@
+package template
+
+var read_go_nameTpl = "read.go"
+var read_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var read_go_contentTpl = `package {{ .Name }}
+
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
+    // TODO(dtm): Add your logic here.
+
+    return nil, nil
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    read_go_nameTpl,
+		DirTpl:     read_go_dirTpl,
+		ContentTpl: read_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/template.go
+++ b/internal/pkg/develop/plugin/template/template.go
@@ -1,0 +1,20 @@
+package template
+
+// TplFile is a file contains some template tags like "{{ .Name }}".
+// eg. internal/pkg/develop/plugin/template/create.go is a TplFile.
+type TplFile struct {
+	NameTpl    string
+	DirTpl     string
+	ContentTpl string
+}
+
+// File is a rendered TplFile that doesn't contain any template tags like "{{ .Name }}".
+type File struct {
+	Name    string
+	Dir     string
+	Content string
+}
+
+// TplFiles filled by functions at other go files.
+// eg. internal/pkg/develop/plugin/template/create.go init()
+var TplFiles = make([]TplFile, 0)

--- a/internal/pkg/develop/plugin/template/update.go
+++ b/internal/pkg/develop/plugin/template/update.go
@@ -1,0 +1,20 @@
+package template
+
+var update_go_nameTpl = "read.go"
+var update_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var update_go_contentTpl = `package {{ .Name }}
+
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
+    // TODO(dtm): Add your logic here.
+
+    return nil, nil
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    update_go_nameTpl,
+		DirTpl:     update_go_dirTpl,
+		ContentTpl: update_go_contentTpl,
+	})
+}

--- a/internal/pkg/develop/plugin/template/validate.go
+++ b/internal/pkg/develop/plugin/template/validate.go
@@ -1,0 +1,20 @@
+package template
+
+var validate_go_nameTpl = "validate.go"
+var validate_go_dirTpl = "internal/pkg/plugin/{{ .Name }}/"
+var validate_go_contentTpl = `package {{ .Name }}
+
+// validate validates the options provided by the core.
+func validate(options *Options) []error {
+    // TODO(dtm): Add your logic here.
+	return make([]error, 0)
+}
+`
+
+func init() {
+	TplFiles = append(TplFiles, TplFile{
+		NameTpl:    validate_go_nameTpl,
+		DirTpl:     validate_go_dirTpl,
+		ContentTpl: validate_go_contentTpl,
+	})
+}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

feat: `dtm develop create-plugin` implement

## Description

This pr only contains code implementation, and the corresponding usage documentation is left in a separate pr, perhaps on the blog we will run recently.

- `./dtm-darwin-arm64 develop create-plugin --name="foo"`

```sh
2022-03-18 13:23:20 ℹ [INFO]  Render template files finished.
2022-03-18 13:23:20 ℹ [INFO]  Persist all files finished.

The DevStream PMC (project management committee) sincerely thank you for your devotion and enthusiasm in creating new plugins!

To make the process easy as a breeze, DevStream(dtm) has generated some templated source code files for you to flatten the learning curve and reduce manual copy-paste.
In the generated templates, dtm has left some special marks in the format of "TODO(dtm)".
Please look for these TODOs by global search. Once you find them, you will know what to do with them. Also, please remember to check our documentation on creating a new plugin:

**README_when_create_plugin.md**

Source code files created.

Happy hacking, buddy!
Please give us feedback through GitHub issues if you encounter any difficulties. We guarantee that you will receive unrivaled help from our passionate community!

```

The files generated:

![image](https://user-images.githubusercontent.com/18692628/158942158-a3a7cf5d-919a-41c2-9587-58cca77047a7.png)

## Related Issues

close #325 

## Last but not least

Thanks to @IronCore864 for helping me reorganize the last output log, this modification makes this feature more shiny!