### PR TITLE
fix: delete unnecessary logs in `handle-result`

### DIFF
--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -116,7 +116,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 		if err != nil {
 			succeeded = false
 		}
-		log.Infof("Tool's changes with filled inputs are: %s.", c.Tool.Options)
+		log.Debugf("Tool's changes with filled inputs: %s.", c.Tool.Options)
 
 		switch c.ActionName {
 		case statemanager.ActionCreate:
@@ -132,7 +132,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 		}
 
 		if err != nil {
-			key := fmt.Sprintf("%s-%s", c.Tool.Name, c.ActionName)
+			key := fmt.Sprintf("%s/%s-%s", c.Tool.Plugin.Kind, c.Tool.Name, c.ActionName)
 			errorsMap[key] = err
 		}
 
@@ -161,8 +161,8 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 	}()
 
 	if !change.Result.Succeeded {
-		log.Errorf("The tool < %s/%s > %s failed.", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
-		return fmt.Errorf("the tool < %s/%s > %s failed", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
+		// do nothing when the change failed
+		return nil
 	}
 
 	if change.ActionName == statemanager.ActionDelete {

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -53,7 +53,7 @@ func Apply(configFile string, continueDirectly bool) error {
 	errsMap := execute(smgr, changes)
 	if len(errsMap) != 0 {
 		for k, e := range errsMap {
-			log.Errorf("%s -> %s", k, e)
+			log.Errorf("Error: key(%s) -> msg: %s", k, e)
 		}
 		return errors.New("some error(s) occurred during plugins apply process")
 	}


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

delete unnecessary logs in `handle-result`

### Current Behavior

```sh
2022-03-18 22:32:17 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-18 22:32:17 ℹ [INFO]  Processing: golang-demo2(kind: github-repo-scaffolding-golang) -> Create ...
2022-03-18 22:32:22 ✖ [ERROR]  The tool < golang-demo2/github-repo-scaffolding-golang > Create failed.
2022-03-18 22:32:22 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-03-18 22:32:22 ✖ [ERROR]  Error: key(github-repo-scaffolding-golang/golang-demo2-Create) -> msg: environment variable GITHUB_TOKEN is not set. Failed to initialize GitHub token. More info - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
2022-03-18 22:32:22 ✖ [ERROR]  Error: key(handle-result) -> msg: the tool < golang-demo2/github-repo-scaffolding-golang > Create failed
2022-03-18 22:32:22 ✖ [ERROR]  Apply failed => some error(s) occurred during plugins apply process.
```

### New Behavior

```sh
2022-03-18 22:46:20 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-18 22:46:20 ℹ [INFO]  Processing: golang-demo3(kind: github-repo-scaffolding-golang) -> Create ...
2022-03-18 22:46:21 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-03-18 22:46:21 ✖ [ERROR]  Error: key(github-repo-scaffolding-golang/golang-demo3-Create) -> msg: environment variable GITHUB_TOKEN is not set. Failed to initialize GitHub token. More info - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
2022-03-18 22:46:21 ✖ [ERROR]  Apply failed => some error(s) occurred during plugins apply process.
```
