### PR TITLE
fix: argocd plugin apply twice trigger update

### DIFF
--- a/internal/pkg/plugin/argocd/state.go
+++ b/internal/pkg/plugin/argocd/state.go
@@ -3,8 +3,9 @@ package argocd
 import "github.com/merico-dev/stream/pkg/util/helm"
 
 var DefaultDeploymentList = []string{
-	"argocd-application-controller",
+	"argocd-applicationset-controller",
 	"argocd-dex-server",
+	"argocd-notifications-controller",
 	"argocd-redis",
 	"argocd-repo-server",
 	"argocd-server",


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

ArgoCD old deployments:

```sh
	"argocd-application-controller",
	"argocd-dex-server",
	"argocd-redis",
	"argocd-repo-server",
	"argocd-server",
```

ArgoCD new deployments:

```sh
	"argocd-applicationset-controller",
	"argocd-dex-server",
	"argocd-notifications-controller",
	"argocd-redis",
	"argocd-repo-server",
	"argocd-server",
```

For this difference, the `argocd` plugin will `update` when apply twice.

---

- `./dtm-darwin-arm64 apply -f config-argocd.yaml`

```sh
2022-03-18 23:45:23 ℹ [INFO]  Apply started.
2022-03-18 23:45:23 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-18 23:45:23 ℹ [INFO]  Tool < argocd-dev > found in config but doesn't exist in the state, will be created.
Continue? [y/n]
Enter a value (Default is n): y

2022-03-18 23:45:24 ℹ [INFO]  Start executing the plan.
2022-03-18 23:45:24 ℹ [INFO]  Changes count: 1.
2022-03-18 23:45:24 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-18 23:45:24 ℹ [INFO]  Processing: argocd-dev(kind: argocd) -> Create ...
2022-03-18 23:45:28 ℹ [INFO]  Creating or updating argocd helm chart ...
2022/03/18 23:45:35 creating 1 resource(s)
2022/03/18 23:45:35 CRD applications.argoproj.io is already present. Skipping.
2022/03/18 23:45:35 creating 1 resource(s)
2022/03/18 23:45:35 CRD applicationsets.argoproj.io is already present. Skipping.
2022/03/18 23:45:35 creating 1 resource(s)
2022/03/18 23:45:35 CRD argocdextensions.argoproj.io is already present. Skipping.
2022/03/18 23:45:36 creating 1 resource(s)
2022/03/18 23:45:36 CRD appprojects.argoproj.io is already present. Skipping.
2022/03/18 23:45:37 creating 44 resource(s)
2022/03/18 23:45:38 release installed successfully: argocd/argo-cd-4.1.0
2022-03-18 23:45:38 ✔ [SUCCESS]  Plugin argocd-dev(argocd) Create done.
2022-03-18 23:45:38 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-03-18 23:45:38 ✔ [SUCCESS]  All plugins applied successfully.
2022-03-18 23:45:38 ✔ [SUCCESS]  Apply finished.
```

- `./dtm-darwin-arm64 apply -f config-argocd.yaml`

```sh
./dtm-darwin-arm64 apply -f config-argocd.yaml        
2022-03-18 23:49:41 ℹ [INFO]  Apply started.
2022-03-18 23:49:41 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-18 23:49:41 ℹ [INFO]  No changes done since last apply. There is nothing to do.
2022-03-18 23:49:41 ✔ [SUCCESS]  Apply finished.
```

- `kgpo -n argocd`

```sh
NAME                                                READY   STATUS    RESTARTS   AGE
argocd-application-controller-0                     1/1     Running   0          15m53s
argocd-applicationset-controller-775b9ff8c7-s2427   1/1     Running   0          15m54s
argocd-dex-server-cc7ccf46-6txrz                    1/1     Running   0          15m53s
argocd-notifications-controller-59fdf89c5c-hb6gc    1/1     Running   0          15m54s
argocd-redis-569947bdc8-mdbkp                       1/1     Running   0          15m54s
argocd-repo-server-6696895796-bm6t5                 1/1     Running   0          15m54s
argocd-server-5dd648c459-mntf4                      1/1     Running   0          15m54s
```