### PR TITLE
feat(helm-style plugins): update without delete

### DIFF
--- a/internal/pkg/plugin/argocd/create.go
+++ b/internal/pkg/plugin/argocd/create.go
@@ -6,12 +6,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
-	"github.com/merico-dev/stream/pkg/util/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 // Create creates ArgoCD with provided options.
 func Create(options map[string]interface{}) (map[string]interface{}, error) {
+	// 1. decode options
 	var param Param
 	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
@@ -24,6 +24,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("params are illegal")
 	}
 
+	// 2. deal with ns
 	if err := DealWithNsWhenInstall(&param); err != nil {
 		return nil, err
 	}
@@ -39,18 +40,12 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		log.Debugf("Deal with namespace when interruption succeeded.")
 	}()
 
-	var h *helm.Helm
-	h, retErr = helm.NewHelm(param.GetHelmParam())
-	if retErr != nil {
+	// 3. install or upgrade
+	if retErr = InstallOrUpgradeChart(&param); retErr != nil {
 		return nil, retErr
 	}
 
-	log.Info("Creating or updating argocd helm chart ...")
-	if retErr = h.InstallOrUpgradeChart(); retErr != nil {
-		log.Debugf("Failed to install or upgrade the Chart: %s.", retErr)
-		return nil, retErr
-	}
-
+	// 4. fill the return map
 	retMap := GetStaticState().ToStringInterfaceMap()
 	log.Debugf("Return map: %v", retMap)
 

--- a/internal/pkg/plugin/argocd/update.go
+++ b/internal/pkg/plugin/argocd/update.go
@@ -1,18 +1,36 @@
 package argocd
 
 import (
-	"time"
+	"fmt"
 
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
-	_, err := Delete(options)
-	if err != nil {
-		log.Errorf("Failed to delete the ArgoCD: %s.", err)
+	// 1. decode options
+	var param Param
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 
-	<-time.NewTicker(3 * time.Second).C
-	return Create(options)
+	if errs := validate(&param); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Param error: %s.", e)
+		}
+		return nil, fmt.Errorf("params are illegal")
+	}
+
+	// 2. install or upgrade
+	if err := InstallOrUpgradeChart(&param); err != nil {
+		return nil, err
+	}
+
+	// 3. fill the return map
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
 }

--- a/internal/pkg/plugin/common/helm/helm.go
+++ b/internal/pkg/plugin/common/helm/helm.go
@@ -32,6 +32,20 @@ func (p *Param) GetHelmParam() *helm.HelmParam {
 	}
 }
 
+func InstallOrUpgradeChart(param *Param) error {
+	h, err := helm.NewHelm(param.GetHelmParam())
+	if err != nil {
+		return err
+	}
+
+	log.Info("Creating or updating helm chart ...")
+	if err := h.InstallOrUpgradeChart(); err != nil {
+		log.Debugf("Failed to install or upgrade the chart: %s.", err)
+		return err
+	}
+	return nil
+}
+
 func DealWithNsWhenInstall(param *Param) error {
 	if !param.CreateNamespace {
 		log.Debugf("There's no need to delete the namespace for the create_namespace == false in the config file.")

--- a/internal/pkg/plugin/jenkins/update.go
+++ b/internal/pkg/plugin/jenkins/update.go
@@ -1,19 +1,38 @@
 package jenkins
 
 import (
-	"time"
+	"fmt"
 
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 // Update updates jenkins with provided options.
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
-	_, err := Delete(options)
-	if err != nil {
-		log.Errorf("Failed to delete the Jenkins: %s.", err)
+	// 1. decode options
+	var param Param
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 
-	<-time.NewTicker(3 * time.Second).C
-	return Create(options)
+	if errs := validate(&param); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Param error: %s.", e)
+		}
+		return nil, fmt.Errorf("params are illegal")
+	}
+
+	// 2. install or upgrade
+	if err := InstallOrUpgradeChart(&param); err != nil {
+		return nil, err
+	}
+
+	// 3. fill the return map
+	releaseName := param.Chart.ReleaseName
+	retMap := GetStaticState(releaseName).ToStringInterfaceMap()
+	log.Debugf("Return map: %v.", retMap)
+
+	return retMap, nil
 }

--- a/internal/pkg/plugin/kubeprometheus/create.go
+++ b/internal/pkg/plugin/kubeprometheus/create.go
@@ -6,12 +6,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
-	"github.com/merico-dev/stream/pkg/util/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 // Create creates kube-prometheus with provided options.
 func Create(options map[string]interface{}) (map[string]interface{}, error) {
+	// 1. decode options
 	var param Param
 	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
@@ -24,6 +24,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("params are illegal")
 	}
 
+	// 2. deal with ns
 	if err := DealWithNsWhenInstall(&param); err != nil {
 		return nil, err
 	}
@@ -39,18 +40,12 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		log.Debugf("Deal with namespace when interruption succeeded.")
 	}()
 
-	var h *helm.Helm
-	h, retErr = helm.NewHelm(param.GetHelmParam())
-	if retErr != nil {
+	// 3. install or upgrade
+	if retErr = InstallOrUpgradeChart(&param); retErr != nil {
 		return nil, retErr
 	}
 
-	log.Info("Installing or updating kube-prometheus-stack helm chart ...")
-	if retErr = h.InstallOrUpgradeChart(); retErr != nil {
-		log.Debugf("Failed to install or upgrade the Chart: %s.", retErr)
-		return nil, retErr
-	}
-
+	// 4. fill the return map
 	releaseName := param.Chart.ReleaseName
 	retMap := GetStaticState(releaseName).ToStringInterfaceMap()
 	log.Debugf("Return map: %v", retMap)

--- a/internal/pkg/plugin/kubeprometheus/update.go
+++ b/internal/pkg/plugin/kubeprometheus/update.go
@@ -1,19 +1,38 @@
 package kubeprometheus
 
 import (
-	"time"
+	"fmt"
 
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 // Update updates kube-prometheus with provided options.
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
-	_, err := Delete(options)
-	if err != nil {
-		log.Errorf("Failed to delete the kube-prometheus: %s", err)
+	// 1. decode options
+	var param Param
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 
-	<-time.NewTicker(3 * time.Second).C
-	return Create(options)
+	if errs := validate(&param); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Param error: %s.", e)
+		}
+		return nil, fmt.Errorf("params are illegal")
+	}
+
+	// 2. install or upgrade
+	if err := InstallOrUpgradeChart(&param); err != nil {
+		return nil, err
+	}
+
+	// 3. fill the return map
+	releaseName := param.Chart.ReleaseName
+	retMap := GetStaticState(releaseName).ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
 }

--- a/internal/pkg/plugin/openldap/update.go
+++ b/internal/pkg/plugin/openldap/update.go
@@ -1,18 +1,36 @@
 package openldap
 
 import (
-	"time"
+	"fmt"
 
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/merico-dev/stream/internal/pkg/plugin/common/helm"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
-	_, err := Delete(options)
-	if err != nil {
-		log.Errorf("Failed to delete the OpenLDAP: %s.", err)
+	// 1. decode options
+	var param Param
+	if err := mapstructure.Decode(options, &param); err != nil {
 		return nil, err
 	}
 
-	<-time.NewTicker(3 * time.Second).C
-	return Create(options)
+	if errs := validate(&param); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Param error: %s.", e)
+		}
+		return nil, fmt.Errorf("params are illegal")
+	}
+
+	// 2. install or upgrade
+	if err := InstallOrUpgradeChart(&param); err != nil {
+		return nil, err
+	}
+
+	// 3. fill the return map
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

feat(helm-style plugins): update without delete

### Current Behavior

update=delete+create

### New Behavior

Both `create` and `update` use the `InstallOrUpgradeChart()` as a main process. The difference is:

- `create` needs to deal with `ns` create/delete` logic
- `update` doesn't need to deal with `ns` create/delete` logic

### Test

1. `./dtm-darwin-arm64 apply -f config-argocd.yaml`

```sh
2022-03-19 14:00:43 ℹ [INFO]  Apply started.
2022-03-19 14:00:43 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-19 14:00:43 ℹ [INFO]  Tool < argocd-dev > found in config but doesn't exist in the state, will be created.
Continue? [y/n]
Enter a value (Default is n): y

2022-03-19 14:00:45 ℹ [INFO]  Start executing the plan.
2022-03-19 14:00:45 ℹ [INFO]  Changes count: 1.
2022-03-19 14:00:45 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-19 14:00:45 ℹ [INFO]  Processing: argocd-dev(kind: argocd) -> Create ...
2022-03-19 14:00:46 ℹ [INFO]  Creating or updating helm chart ...
2022/03/19 14:00:48 creating 1 resource(s)
2022/03/19 14:00:48 CRD applications.argoproj.io is already present. Skipping.
2022/03/19 14:00:48 creating 1 resource(s)
2022/03/19 14:00:48 CRD applicationsets.argoproj.io is already present. Skipping.
2022/03/19 14:00:48 creating 1 resource(s)
2022/03/19 14:00:48 CRD argocdextensions.argoproj.io is already present. Skipping.
2022/03/19 14:00:48 creating 1 resource(s)
2022/03/19 14:00:48 CRD appprojects.argoproj.io is already present. Skipping.
2022/03/19 14:00:50 creating 44 resource(s)
2022/03/19 14:00:50 release installed successfully: argocd/argo-cd-4.2.1
2022-03-19 14:00:50 ✔ [SUCCESS]  Plugin argocd-dev(argocd) Create done.
2022-03-19 14:00:50 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-03-19 14:00:50 ✔ [SUCCESS]  All plugins applied successfully.
2022-03-19 14:00:50 ✔ [SUCCESS]  Apply finished.
```

2. `./dtm-darwin-arm64 apply -f config-argocd.yaml`

```sh
2022-03-19 14:01:18 ℹ [INFO]  Apply started.
2022-03-19 14:01:18 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-19 14:01:18 ℹ [INFO]  No changes done since last apply. There is nothing to do.
2022-03-19 14:01:18 ✔ [SUCCESS]  Apply finished.
```

3. modify the config-argocd.yaml, then execute `./dtm-darwin-arm64 apply -f config-argocd.yaml`

```sh
2022-03-19 14:01:39 ℹ [INFO]  Apply started.
2022-03-19 14:01:39 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-03-19 14:01:39 ℹ [INFO]  Tool < argocd-dev > config drifted from the state, will be updated.
Continue? [y/n]
Enter a value (Default is n): y

2022-03-19 14:01:40 ℹ [INFO]  Start executing the plan.
2022-03-19 14:01:40 ℹ [INFO]  Changes count: 1.
2022-03-19 14:01:40 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-03-19 14:01:40 ℹ [INFO]  Processing: argocd-dev(kind: argocd) -> Update ...
2022-03-19 14:01:42 ℹ [INFO]  Creating or updating helm chart ...
2022/03/19 14:01:43 upgrading crds
2022/03/19 14:01:43 INFO: new version of CRD "applications.argoproj.io" contains no changes, skipping upgrade
2022/03/19 14:01:43 CRD crds/crd-application.yaml upgraded successfully for chart: argo-cd
2022/03/19 14:01:43 INFO: new version of CRD "applicationsets.argoproj.io" contains no changes, skipping upgrade
2022/03/19 14:01:43 CRD crds/crd-applicationset.yaml upgraded successfully for chart: argo-cd
2022/03/19 14:01:43 INFO: new version of CRD "argocdextensions.argoproj.io" contains no changes, skipping upgrade
2022/03/19 14:01:43 CRD crds/crd-extension.yaml upgraded successfully for chart: argo-cd
2022/03/19 14:01:43 INFO: new version of CRD "appprojects.argoproj.io" contains no changes, skipping upgrade
2022/03/19 14:01:43 CRD crds/crd-project.yaml upgraded successfully for chart: argo-cd
2022/03/19 14:01:43 preparing upgrade for argocd
2022/03/19 14:01:45 performing update for argocd
2022/03/19 14:01:45 creating upgraded release for argocd
2022/03/19 14:01:45 checking 44 resources for changes
2022/03/19 14:01:45 Looks like there are no changes for ServiceAccount "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for ServiceAccount "argocd-repo-server"
2022/03/19 14:01:45 Looks like there are no changes for ServiceAccount "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for ServiceAccount "argocd-dex-server"
2022/03/19 14:01:45 Looks like there are no changes for Secret "argocd-secret"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-cm"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-gpg-keys-cm"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-rbac-cm"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-ssh-known-hosts-cm"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-tls-certs-cm"
2022/03/19 14:01:45 Looks like there are no changes for ConfigMap "argocd-notifications-controller-cm"
2022/03/19 14:01:45 Looks like there are no changes for ClusterRole "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for ClusterRole "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for ClusterRoleBinding "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for ClusterRoleBinding "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-applicationset-controller"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-notifications-controller"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-repo-server"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for Role "argocd-dex-server"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-applicationset-controller"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-notifications-controller"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-repo-server"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for RoleBinding "argocd-dex-server"
2022/03/19 14:01:45 Looks like there are no changes for Service "argocd-application-controller"
2022/03/19 14:01:45 Looks like there are no changes for Service "argocd-repo-server"
2022/03/19 14:01:45 Looks like there are no changes for Service "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for Service "argocd-dex-server"
2022/03/19 14:01:45 Looks like there are no changes for Service "argocd-redis"
2022/03/19 14:01:45 Looks like there are no changes for Deployment "argocd-applicationset-controller"
2022/03/19 14:01:45 Looks like there are no changes for Deployment "argocd-repo-server"
2022/03/19 14:01:45 Looks like there are no changes for Deployment "argocd-server"
2022/03/19 14:01:45 Looks like there are no changes for Deployment "argocd-dex-server"
2022/03/19 14:01:45 Looks like there are no changes for Deployment "argocd-redis"
2022/03/19 14:01:45 Looks like there are no changes for StatefulSet "argocd-application-controller"
2022/03/19 14:01:46 updating status for upgraded release for argocd
2022/03/19 14:01:46 release upgraded successfully: argocd/argo-cd-4.2.1
2022-03-19 14:01:46 ✔ [SUCCESS]  Plugin argocd-dev(argocd) Update done.
2022-03-19 14:01:46 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-03-19 14:01:46 ✔ [SUCCESS]  All plugins applied successfully.
2022-03-19 14:01:46 ✔ [SUCCESS]  Apply finished.
```