### PR TITLE
Docs dtm destroy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This document summarizes the main components of DevStream and how data flows between these components.
 
-## 0. Data Flow
+## 0 Data Flow
 
 The following diagram shows an approximation of how DevStream executes a user command:
 
@@ -14,7 +14,7 @@ There are three major parts:
 - `pluginengine`: the plugin engine, which achieves the core functionalities by calling other modules (`configloader`, `pluginmanager`, `statemanager`, etc.)
 - plugins: implements the actual CRUD interfaces for a certain DevOps tool
 
-## 1. CLI (The `devstream` Package)
+## 1 CLI (The `devstream` Package)
 
 Note: for simplicity, the CLI is named `dtm`(DevOps Tool Manager) instead of the full name DevStream.
 
@@ -28,7 +28,7 @@ Then it calls the `pluginmanager` to download the required plugins.
 
 After that, the `pluginengine` calls the state manager to calculate "changes" between the congfig, the state, and the actual DevOps tool's status. At last, the `pluginengine` executes actions according to the changes, and updates the state. During the execution, the `pluginengine` loads each plugin (`*.so` file) and calls the predefined interface according to each change.
 
-## 2. Plugin Engine
+## 2 Plugin Engine
 
 The `pluginengine` has various responsibilities:
 
@@ -54,7 +54,7 @@ The [`statemanager`](https://github.com/merico-dev/stream/blob/main/internal/pkg
 
 The `statemanager` stores the state in a [`backend`](https://github.com/merico-dev/stream/blob/main/internal/pkg/backend/backend.go).
 
-## 3. Plugin
+## 3 Plugin
 
 A _plugin_ implements the aforementioned, predefined interfaces.
 

--- a/docs/commands_explained.md
+++ b/docs/commands_explained.md
@@ -1,0 +1,53 @@
+# Commands Explained
+
+## 1 `dtm apply`
+
+When _applying_ a config file using `dtm`, here's what happens:
+
+### 1.1 For Each _Tool_ Defined in the _Config_
+
+We compare the _Tool_, its _State_, and the _Resoruce_ it has created before (if the state exists).
+
+We generate a plan of changes according to the comparison result:
+- If the _Tool_ isn't in the _State_, the `Create` interface will be called.
+- If the _Tool_ is in the _State_, but the _Config_ is different than the _State_ (meaning users probably updated the config after the last `apply`,) the `Update` interface will be called.
+- If the _Tool_ is in the _State_, and the _Config_ is the same as the _State_, we try to read the _Resource_.
+    - If the _Resource_ doesn't exist, the `Create` interface will be called. It probably suggests that the _Resource_ got deleted manually after the last successful `apply`.
+    - If the _Resource_ does exist but drifted from the _State_ (meaning somebody modified it), the `Update` interface will be called.
+    - Last but not least, nothing would happen if the _Resource_ is exactly the same as the _State_.
+
+### 1.2 For Each _State_ That Doesn't Have a _Tool_ in the _Config_
+
+We generate a "Delete" change to delete the _Resource_. Since there isn't a _Tool_ in the config but there is a _State_, it means maybe the _Resource_ had been created previously then the user removed the _Tool_ from the _Config_, which means the user doesn't want the _Resource_ any more.
+
+## 2 `dtm delete`
+
+### 2.1 Normal (Non-Force) Delete
+
+When _deleting_ using `dtm`, here's what happens:
+
+- Read the _Config_
+- For each _Tool_ defined in the _Config_, if there is a corresponding _State_, the `Delete` interface will be called.
+
+_Note: the `Delete` change will be executed only if the _State_ exists._
+
+### 2.2 Force Delete
+
+When _deleting_ using `dtm delete --force`, here's what happens:
+
+- Read the _Config_
+- The `Delete` interface will be called for each _Tool_ defined in the _Config_.
+
+_Note: the difference between "force delete" and "normal delete" is that in force mode, no matter the _State_ exists or not, `dtm` will try to trigger the `Delete` interface. The purpose is for corner cases where the state gets corrupted or even lost during testing (I hope this only happens in the development environment), there is still a way to clean up the _Tools_._
+
+## 3 `dtm destroy`
+
+`dtm destroy` acts like `dtm apply -f an_empty_config.yaml`. 
+
+The purpose of `destroy` is that in case you accidentally deleted your config file during testing, there would still be a way to destroy everything that is defined in the _State_ so that you can have a clean slate.
+
+```{toctree}
+---
+maxdepth: 1
+---
+```

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -2,40 +2,22 @@
 
 The architecture documentation explains how in general DevStream works. If you haven't read it yet, make sure you do that before continuing with this document.
 
-## 1. Config, State, and Resource
+## 1 Config
 
-Config
 - The _Config_ is a list of tools, defined in [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/configloader/config.go#L19).
 - Each _Tool_ has its Name, Plugin, and Options, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/configloader/config.go#L24).
 - Each _Tool_ can have its dependencies, which are specified by the `dependsOn` keyword.
 
 The dependency `dependsOn` is an array of strings, with each element being a dependency. Each dependency is named in the format of "NAME.KIND". See [here](https://github.com/merico-dev/stream/blob/main/examples/quickstart.yaml#L16) for example.
 
-State
+## 2 State
+
 - The _State_ is actually a map of states, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L21).
 - Each state in the map is a struct containing Name, Plugin, Options, and Resource, as defined [here](https://github.com/merico-dev/stream/blob/main/internal/pkg/statemanager/state.go#L14).
 
-Resource
+## 3 Resource
+
 - We call what the plugin created a _Resource_, and the `Read()` interface of that plugin returns a description of that resource, which is in turn stored as part of the state.
-
-## 2. Changes for `dtm apply`
-
-When _applying_ a config file using `dtm`, here's what happens:
-
-- Read the _State_
-- For each _Tool_ defined in the _Config_, we compare the _Tool_, its _State_, and the _Resoruce_ it has created before (if the state exists). We create some changes based on that.
-- For each _State_ that doesn't have a _Tool_ in the _Config_, we generate a "Delete" change to delete the _Resource_. Since there isn't a _Tool_ in the config but there is a _State_, it means maybe the _Resource_ had been created previously then the user removed the _Tool_ from the _Config_, which means the user doesn't want the _Resource_ any more.
-
-## 3. Changes for `dtm delete`
-
-When _deleting_ using `dtm`, here's what happens:
-
-- Read the _Config_ only
-- For each _Tool_ defined in the _Config_, if there is a corresponding _State_, we generate a "Delete" change.
-
-## 4. Changes for `dtm destroy`
-
-TODO.
 
 ```{toctree}
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,11 @@ maxdepth: 1
 ---
 overview
 quickstart_en
-core_concept
+architecture
+core_concepts
+commands_explained
 development_workflow
 project_layout
-architecture
 creating_a_plugin
 roadmap
 Releases ⧉ <https://github.com/merico-dev/stream/releases>

--- a/docs/quickstart_en.md
+++ b/docs/quickstart_en.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-## 1. Download DevStream (`dtm`)
+## 1 Download DevStream (`dtm`)
 
 Download the appropriate `dtm` version for your platform from [DevStream Releases](https://github.com/merico-dev/stream/releases).
 
@@ -8,7 +8,7 @@ Download the appropriate `dtm` version for your platform from [DevStream Release
 
 > Once downloaded, you can run the binary from anywhere. Ideally, you want to put it in a place that is in your PATH (e.g., `/usr/local/bin`).
 
-## 2. Prepare a Config File
+## 2 Prepare a Config File
 
 Copy the [examples/quickstart.yaml](../examples/quickstart.yaml) to your working directory and rename it to `config.yaml`:
 
@@ -36,7 +36,7 @@ export GITHUB_TOKEN="YOUR_GITHUB_TOKEN_HERE"
 
 If you don't know how to create a GitHub token, check out [the official document here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
-## 3. Initialize
+## 3 Initialize
 
 Run:
 
@@ -60,7 +60,7 @@ and you should see similar output to:
 
 This step downloads the required plugins according to the config file.
 
-## 4. Apply
+## 4 Apply
 
 Run:
 
@@ -95,11 +95,11 @@ Enter a value (Default is n): y
 2022-03-04 12:09:26 ✔ [SUCCESS]  All plugins applied successfully.
 2022-03-04 12:09:26 ✔ [SUCCESS]  Apply finished.
 ```
-## 5. Check the Results
+## 5 Check the Results
 
 Go to your GitHub account, and we can see a new repo named "go-webapp-devstream-demo" has been created; there are some Golang web app scaffolding lying around already, and the GitHub Actions for building the app is also ready. Hooray!
 
-## 6. Clean Up
+## 6 Clean Up
 
 Run:
 

--- a/docs/quickstart_zh.md
+++ b/docs/quickstart_zh.md
@@ -2,7 +2,7 @@
 
 > 中文 | [English](./quickstart_en.md)
 
-## 1. 下载 DevStream (`dtm`)
+## 1 下载 DevStream (`dtm`)
 
 根据你的实际环境从 [DevStream Releases](https://github.com/merico-dev/stream/releases) 下载合适的 `dtm` 版本。
 
@@ -10,7 +10,7 @@
 
 > 一旦下载完成，你就可以将 dtm 文件放到任何目录下运行了。当然更加建议你将 dtm 加到 PATH 下(比如 `/usr/local/bin`)。
 
-## 2. 准备一个配置文件
+## 2 准备一个配置文件
 
 将 [examples/quickstart.yaml](../examples/quickstart.yaml) 文件拷贝到你到工作目录下，然后重命名成 `config.yaml`：
 
@@ -38,7 +38,7 @@ export GITHUB_TOKEN="YOUR_GITHUB_TOKEN_HERE"
 
 如果你不知道怎么创建一个 GitHub token 可以看下[官方文档](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) 。
 
-## 3. 初始化
+## 3 初始化
 
 运行：
 
@@ -62,7 +62,7 @@ dtm init -f config.yaml
 
 这一步会根据配置文件来下载需要的插件。
 
-## 4. 开始执行
+## 4 开始执行
 
 运行：
 
@@ -97,12 +97,12 @@ Enter a value (Default is n): y
 2022-03-04 12:09:26 ✔ [SUCCESS]  All plugins applied successfully.
 2022-03-04 12:09:26 ✔ [SUCCESS]  Apply finished.
 ```
-## 5. 检查结果
+## 5 检查结果
 
 登录你自己的 GitHub 账户，然后你可以看到一个新的名字叫做 "go-webapp-devstream-demo" 的项目已经被创建出来了，
 而且里面已经有了一些 Golang 的 web 应用脚手架代码。另外你还可以看到用于构建这个应用的一些 GitHub Actions 也已经被配置好了。酷吧？
 
-## 6. 清理
+## 6 清理
 
 运行：
 

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -154,7 +154,7 @@ func changesForDelete(smgr statemanager.Manager, cfg *configloader.Config) []*Ch
 	return changes
 }
 
-// changesForForceDelete  for force delete from config, ignore state file
+// changesForForceDelete for force delete from config, ignore state file
 func changesForForceDelete(smgr statemanager.Manager, cfg *configloader.Config) []*Change {
 	changes := make([]*Change, 0)
 


### PR DESCRIPTION
# Summary

Thanks @[algobot76](https://github.com/merico-dev/stream/issues?q=is%3Aissue+is%3Aopen+author%3Aalgobot76) for contributing a doc related issue!

## Key Points

- [x] Documentation (new or existing) is updated.

## Description

- core_concept.md renamed to core_concepts.md
- command related explanation is moved out of core_concepts.md and into a new doc commands_explained.md
- `dtm destroy` doc is added into commands_explained.md
- reorder the docs in [readthedocs.io
](https://docs.dtm.dev/en/latest/) to make it more logical
- minor comment format update in one src file

## Related Issues

Closes #339 
