### PR TITLE
fix: change main_go_dir to `cmd/plugin/`

### DIFF
--- a/internal/pkg/develop/plugin/template/main.go
+++ b/internal/pkg/develop/plugin/template/main.go
@@ -1,7 +1,7 @@
 package template
 
 var main_go_nameTpl = "main.go"
-var main_go_dirTpl = "cmd/{{ .Name }}/"
+var main_go_dirTpl = "cmd/plugin/{{ .Name }}/"
 var main_go_contentTpl = `package main
 
 import (


### PR DESCRIPTION
# Summary

The main.go file of the plugin has been moved from `/cmd/{plugin_name}/main.go` to `/cmd/plugin/{plugin_name}/main.go`, but the template of the plugin generation tool is not synchronized, this commit fixes the problem
