### PR TITLE
chore: revert the workflow name with 'main builder'

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -1,4 +1,4 @@
-name: pushed to main
+name: main builder
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

It's my fault, I didn't know the name would show up here before. 

In other words, if it needs to show here, I think the `main builder` is more suitable.

### Screenshots

![image](https://user-images.githubusercontent.com/18692628/160266198-cac2eba2-73b4-4897-9b0f-226ba1cef46e.png)
