### PR TITLE
chore: remove `Foo string` field

### DIFF
--- a/internal/pkg/develop/plugin/template/options.go
+++ b/internal/pkg/develop/plugin/template/options.go
@@ -7,7 +7,6 @@ var options_go_contentTpl = `package {{ .Name }}
 // Options is the struct for configurations of the {{ .Name }} plugin.
 type Options struct {
     // TODO(dtm): Add your params here.
-	Foo string
 }
 `
 


### PR DESCRIPTION
# Summary

`Foo string` field is not necessary in the `options.go` template