### PR TITLE
ci: improve makefile for multi-threaded build and readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+VERSION=0.3.0
+
 MKFILE_PATH=$(abspath $(lastword $(MAKEFILE_LIST)))
 BUILD_PATH=$(patsubst %/,%,$(dir $(MKFILE_PATH)))/build/working_dir
-VERSION=0.3.0
+
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
-PLUGINS_CMD_ROOT=./cmd/plugin
 GO_BUILD=go build -buildmode=plugin -trimpath -gcflags="all=-N -l"
+
+PLUGINS_CMD_ROOT=./cmd/plugin
 PLUGINS_DIR=$(shell find ${PLUGINS_CMD_ROOT} -name "main.go" -exec dirname {} \;)
 PLUGINS_NAME=$(notdir ${PLUGINS_DIR})
 PLUGIN_SUFFIX=${GOOS}-${GOARCH}_${VERSION}
@@ -14,14 +17,17 @@ ifeq ($(GOOS),linux)
 else
 	MD5SUM=md5 -q
 endif
+
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9.%-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: build
-build: build-core build-plugins md5 ## Build dtm core & plugins locally.
-	rm -f dtm
-	mv dtm-${GOOS}-${GOARCH} dtm
+.PHONY: clean
+clean: ## Remove dtm and plugins. It's best to run a "clean" before "build".
+	rm -rf .devstream
+	rm -f dtm*
+	rm -f *.md5
+	rm -rf build/working_dir
 
 .PHONY: build-core
 build-core: fmt vet mod-tidy ## Build dtm core only, without plugins, locally.
@@ -33,10 +39,15 @@ build-plugin.%: fmt vet mod-tidy mkdir.devstream ## Build one dtm plugin, like "
 	${GO_BUILD} -o .devstream/${plugin_name}-${PLUGIN_SUFFIX}.so ${PLUGINS_CMD_ROOT}/${plugin_name}
 
 .PHONY: build-plugins
-build-plugins: fmt vet mod-tidy $(addprefix build-plugin.,$(PLUGINS_NAME)) ## Build dtm plugins only, without core, locally.
+build-plugins: fmt vet mod-tidy $(addprefix build-plugin.,$(PLUGINS_NAME)) ## Build dtm plugins only. Use multi-threaded like "make build-plugins -j8" to speed up.
 
-.PHONY: md5
-md5: md5-core md5-plugins
+.PHONY: build
+build: build-core build-plugins ## Build everything. Use multi-threaded like "make build -j8" to speed up.
+	cp dtm-${GOOS}-${GOARCH} dtm
+
+.PHONY: release
+release: md5-core md5-plugins ## Create md5 sums for all plugins and dtm and make a release.
+	echo "TODO: run scripts for release (uploading plugins and md5 sums)"
 
 .PHONY: md5-core
 md5-core:
@@ -50,12 +61,6 @@ md5-plugin.%:
 	$(eval plugin_name := $(strip $*))
 	${MD5SUM} .devstream/${plugin_name}-${PLUGIN_SUFFIX}.so > .devstream/${plugin_name}-${PLUGIN_SUFFIX}.md5
 
-
-.PHONY: clean
-clean: ## Remove local plugins and locally built artifacts.
-	rm -rf .devstream
-	rm -f dtm*
-	rm -rf build/working_dir
 
 .PHONY: build-linux-amd64
 build-linux-amd64: ## Cross-platform build for "linux/amd64".
@@ -71,7 +76,6 @@ build-linux-amd64: ## Cross-platform build for "linux/amd64".
 	mv ${BUILD_PATH}/output/dtm* .
 	rm -rf ${BUILD_PATH}
 
-
 .PHONY: fmt
 fmt: ## Run 'go fmt' & goimports against code.
 	go install golang.org/x/tools/cmd/goimports@latest
@@ -82,15 +86,15 @@ fmt: ## Run 'go fmt' & goimports against code.
 	go fmt ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: ## Run "go vet ./...".
 	go vet ./...
 
 .PHONY: mod-tidy
-mod-tidy: ## Run go mod tidy
+mod-tidy: ## Run "go mod tidy".
 	go mod tidy
 
 .PHONY: mkdir.devstream
-mkdir.devstream:  ## make .devstream directory
+mkdir.devstream:  ## Create ".devstream" (default directory for plugins) directory.
 	mkdir -p .devstream
 
 .PHONY: e2e

--- a/Makefile
+++ b/Makefile
@@ -32,22 +32,23 @@ clean: ## Remove dtm and plugins. It's best to run a "clean" before "build".
 .PHONY: build-core
 build-core: fmt vet mod-tidy ## Build dtm core only, without plugins, locally.
 	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
+	$(MAKE) md5-core
+	cp dtm-${GOOS}-${GOARCH} dtm
 
 .PHONY: build-plugin.%
 build-plugin.%: fmt vet mod-tidy mkdir.devstream ## Build one dtm plugin, like "make build-plugin.argocd"
 	$(eval plugin_name := $(strip $*))
 	${GO_BUILD} -o .devstream/${plugin_name}-${PLUGIN_SUFFIX}.so ${PLUGINS_CMD_ROOT}/${plugin_name}
+	$(MAKE) md5-plugin.$(plugin_name)
 
 .PHONY: build-plugins
 build-plugins: fmt vet mod-tidy $(addprefix build-plugin.,$(PLUGINS_NAME)) ## Build dtm plugins only. Use multi-threaded like "make build-plugins -j8" to speed up.
 
 .PHONY: build
 build: build-core build-plugins ## Build everything. Use multi-threaded like "make build -j8" to speed up.
-	cp dtm-${GOOS}-${GOARCH} dtm
 
-.PHONY: release
-release: md5-core md5-plugins ## Create md5 sums for all plugins and dtm and make a release.
-	echo "TODO: run scripts for release (uploading plugins and md5 sums)"
+.PHONY: md5
+md5: md5-core md5-plugins ## Create md5 sums for all plugins and dtm
 
 .PHONY: md5-core
 md5-core:

--- a/README.md
+++ b/README.md
@@ -176,10 +176,18 @@ git clone https://github.com/merico-dev/stream.git
 
 ```bash
 cd ~/gocode/stream
-make build
-# this step is only required before v0.3
-# TODO(daniel-hutao): remove all `mv` operations including quick-start documents when the next version is released
+make clean
+make build -j8
 mv dtm-$(go env GOOS)-$(go env GOARCH) dtm
+```
+
+We now support build only "dtm", build a specific plugin, and build all plugins. Examples:
+
+```bash
+cd ~/gocode/stream
+make build-core
+make build-plugins -j8
+make build-plugin make build-plugin.argocd
 ```
 
 See the Makefile for more info.
@@ -190,12 +198,17 @@ $ make help
 Usage:
   make <target>
   help                Display this help.
-  build               Build dtm & plugins locally.
+  clean               Remove dtm and plugins. It's best to run a "clean" before "build".
   build-core          Build dtm core only, without plugins, locally.
-  clean               Remove local plugins and locally built artifacts.
+  build-plugin.%      Build one dtm plugin, like "make build-plugin.argocd"
+  build-plugins       Build dtm plugins only. Use multi-threaded like "make build-plugins -j8" to speed up.
+  build               Build everything. Use multi-threaded like "make build -j8" to speed up.
+  release             Create md5 sums for all plugins and dtm and make a release.
   build-linux-amd64   Cross-platform build for "linux/amd64".
   fmt                 Run 'go fmt' & goimports against code.
-  vet                 Run go vet against code.
+  vet                 Run "go vet ./...".
+  mod-tidy            Run "go mod tidy".
+  mkdir.devstream     Create ".devstream" (default directory for plugins) directory.
   e2e                 Run e2e tests.
   e2e-up              Start kind cluster for e2e tests.
   e2e-down            Stop kind cluster for e2e tests.

--- a/README.md
+++ b/README.md
@@ -174,45 +174,22 @@ git clone https://github.com/merico-dev/stream.git
 
 #### Build
 
+To do a multi-threaded build, run:
+
 ```bash
 cd ~/gocode/stream
 make clean
 make build -j8
-mv dtm-$(go env GOOS)-$(go env GOARCH) dtm
 ```
 
-We now support build only "dtm", build a specific plugin, and build all plugins. Examples:
+This builds everything: `dtm` and all the plugins.
 
-```bash
-cd ~/gocode/stream
-make build-core
-make build-plugins -j8
-make build-plugin make build-plugin.argocd
-```
+We also support the following build modes:
+- Build `dtm` only: `make build-core`.
+- Build a specific plugin: `make build-plugin.PLUGIN_NAME`. Example: `make build-plugin.argocd`.
+- Build all plugins: `make build-plugins -j8` (multi-threaded build.)
 
-See the Makefile for more info.
-
-```makefile
-$ make help
-
-Usage:
-  make <target>
-  help                Display this help.
-  clean               Remove dtm and plugins. It's best to run a "clean" before "build".
-  build-core          Build dtm core only, without plugins, locally.
-  build-plugin.%      Build one dtm plugin, like "make build-plugin.argocd"
-  build-plugins       Build dtm plugins only. Use multi-threaded like "make build-plugins -j8" to speed up.
-  build               Build everything. Use multi-threaded like "make build -j8" to speed up.
-  release             Create md5 sums for all plugins and dtm and make a release.
-  build-linux-amd64   Cross-platform build for "linux/amd64".
-  fmt                 Run 'go fmt' & goimports against code.
-  vet                 Run "go vet ./...".
-  mod-tidy            Run "go mod tidy".
-  mkdir.devstream     Create ".devstream" (default directory for plugins) directory.
-  e2e                 Run e2e tests.
-  e2e-up              Start kind cluster for e2e tests.
-  e2e-down            Stop kind cluster for e2e tests.
-```
+See `make help` for more information.
 
 #### Test
 


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.
- [x] Documentation (new or existing) is updated.

## Description

Thanks @algobot76 for raising this issue. This PR reorganized our makefile so that we could simply run "make build -j8" to speed things up.

Ideal releasing process:

- make clean
- make build -j8
- make release

This will be reflected in a release document soon.

Also, some re-order, adding/removing empty lines are done, so that the Makefile is more human-readable.

### Related Issues

Closes #361 

### Screenshots

```shell
tiexin@MBA ~/work/stream $ make clean && \time make build -j8
rm -rf .devstream
rm -f dtm*
rm -f *.md5
rm -rf build/working_dir
go install golang.org/x/tools/cmd/goimports@latest
go vet ./...
go mod tidy
mkdir -p .devstream
goimports -local="github.com/merico-dev/stream" -d -w cmd
goimports -local="github.com/merico-dev/stream" -d -w pkg
goimports -local="github.com/merico-dev/stream" -d -w internal
goimports -local="github.com/merico-dev/stream" -d -w test
go fmt ./...
go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=0.3.0" -o dtm-darwin-arm64 ./cmd/devstream/
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/github-repo-scaffolding-golang-darwin-arm64_0.3.0.so ./cmd/plugin/github-repo-scaffolding-golang
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/trello-github-integ-darwin-arm64_0.3.0.so ./cmd/plugin/trello-github-integ
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-golang-darwin-arm64_0.3.0.so ./cmd/plugin/githubactions-golang
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocd-darwin-arm64_0.3.0.so ./cmd/plugin/argocd
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/gitlabci-golang-darwin-arm64_0.3.0.so ./cmd/plugin/gitlabci-golang
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/jira-github-integ-darwin-arm64_0.3.0.so ./cmd/plugin/jira-github-integ
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-python-darwin-arm64_0.3.0.so ./cmd/plugin/githubactions-python
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/githubactions-nodejs-darwin-arm64_0.3.0.so ./cmd/plugin/githubactions-nodejs
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/devlake-darwin-arm64_0.3.0.so ./cmd/plugin/devlake
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/kube-prometheus-darwin-arm64_0.3.0.so ./cmd/plugin/kube-prometheus
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/trello-darwin-arm64_0.3.0.so ./cmd/plugin/trello
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/jenkins-darwin-arm64_0.3.0.so ./cmd/plugin/jenkins
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/openldap-darwin-arm64_0.3.0.so ./cmd/plugin/openldap
go build -buildmode=plugin -trimpath -gcflags="all=-N -l" -o .devstream/argocdapp-darwin-arm64_0.3.0.so ./cmd/plugin/argocdapp
cp dtm-darwin-arm64 dtm
/Library/Developer/CommandLineTools/usr/bin/make md5
md5 -q dtm-darwin-arm64 > dtm-darwin-arm64.md5
md5 -q .devstream/github-repo-scaffolding-golang-darwin-arm64_0.3.0.so > .devstream/github-repo-scaffolding-golang-darwin-arm64_0.3.0.md5
md5 -q .devstream/trello-github-integ-darwin-arm64_0.3.0.so > .devstream/trello-github-integ-darwin-arm64_0.3.0.md5
md5 -q .devstream/githubactions-golang-darwin-arm64_0.3.0.so > .devstream/githubactions-golang-darwin-arm64_0.3.0.md5
md5 -q .devstream/argocd-darwin-arm64_0.3.0.so > .devstream/argocd-darwin-arm64_0.3.0.md5
md5 -q .devstream/gitlabci-golang-darwin-arm64_0.3.0.so > .devstream/gitlabci-golang-darwin-arm64_0.3.0.md5
md5 -q .devstream/jira-github-integ-darwin-arm64_0.3.0.so > .devstream/jira-github-integ-darwin-arm64_0.3.0.md5
md5 -q .devstream/githubactions-python-darwin-arm64_0.3.0.so > .devstream/githubactions-python-darwin-arm64_0.3.0.md5
md5 -q .devstream/githubactions-nodejs-darwin-arm64_0.3.0.so > .devstream/githubactions-nodejs-darwin-arm64_0.3.0.md5
md5 -q .devstream/devlake-darwin-arm64_0.3.0.so > .devstream/devlake-darwin-arm64_0.3.0.md5
md5 -q .devstream/kube-prometheus-darwin-arm64_0.3.0.so > .devstream/kube-prometheus-darwin-arm64_0.3.0.md5
md5 -q .devstream/trello-darwin-arm64_0.3.0.so > .devstream/trello-darwin-arm64_0.3.0.md5
md5 -q .devstream/jenkins-darwin-arm64_0.3.0.so > .devstream/jenkins-darwin-arm64_0.3.0.md5
md5 -q .devstream/openldap-darwin-arm64_0.3.0.so > .devstream/openldap-darwin-arm64_0.3.0.md5
md5 -q .devstream/argocdapp-darwin-arm64_0.3.0.so > .devstream/argocdapp-darwin-arm64_0.3.0.md5
       17.01 real        70.58 user        22.37 sys
```