### PR TITLE
feat: remove plugin version from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,9 @@ clean: ## Remove dtm and plugins. It's best to run a "clean" before "build".
 
 .PHONY: build-core
 build-core: fmt vet mod-tidy ## Build dtm core only, without plugins, locally.
-	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
+	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/internal/pkg/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 	$(MAKE) md5-core
+	rm -f dtm
 	cp dtm-${GOOS}-${GOARCH} dtm
 
 .PHONY: build-plugin.%

--- a/cmd/devstream/version.go
+++ b/cmd/devstream/version.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/merico-dev/stream/cmd/devstream/version"
+	"github.com/merico-dev/stream/internal/pkg/version"
 )
 
 var versionCMD = &cobra.Command{

--- a/cmd/devstream/version/version.go
+++ b/cmd/devstream/version/version.go
@@ -1,8 +1,0 @@
-package version
-
-// Version is the version of DevStream.
-// Assignment by the command:
-// `go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/merico-dev/stream/cmd/devstream/version.Version=${VERSION}" \
-// -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/`
-// See the Makefile for more info.
-var Version string

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/merico-dev/stream/internal/pkg/version"
 	"github.com/merico-dev/stream/pkg/util/log"
 )
 
@@ -28,7 +29,7 @@ type Tool struct {
 	// start with an alphanumeric character
 	// end with an alphanumeric character
 	Name      string                 `yaml:"name"`
-	Plugin    Plugin                 `yaml:"plugin"`
+	Plugin    string                 `yaml:"plugin"`
 	DependsOn []string               `yaml:"dependsOn"`
 	Options   map[string]interface{} `yaml:"options"`
 }
@@ -46,12 +47,6 @@ func (t *Tool) DeepCopy() *Tool {
 	return &retTool
 }
 
-// Plugin is the struct for the plugin section of each tool of the DevStream configuration file.
-type Plugin struct {
-	Kind    string `mapstructure:"kind"`
-	Version string `mapstructure:"version"`
-}
-
 // LoadConf reads an input file as a Config struct.
 func LoadConf(fname string) *Config {
 	fileBytes, err := ioutil.ReadFile(fname)
@@ -67,7 +62,8 @@ func LoadConf(fname string) *Config {
 	var config Config
 	err = yaml.Unmarshal(fileBytes, &config)
 	if err != nil {
-		log.Errorf("Unmarshal the config failed: %s.", err)
+		log.Error("Please verify the format of your config file.")
+		log.Errorf("Reading config file failed. %s.", err)
 		return nil
 	}
 
@@ -86,12 +82,12 @@ func LoadConf(fname string) *Config {
 // GetPluginFileName creates the file name based on the tool's name and version
 // If the plugin {githubactions 0.0.1}, the generated name will be "githubactions_0.0.1.so"
 func GetPluginFileName(t *Tool) string {
-	return fmt.Sprintf("%s-%s-%s_%s.so", t.Plugin.Kind, GOOS, GOARCH, t.Plugin.Version)
+	return fmt.Sprintf("%s-%s-%s_%s.so", t.Plugin, GOOS, GOARCH, version.Version)
 }
 
 // GetPluginMD5FileName  If the plugin {githubactions 0.0.1}, the generated name will be "githubactions_0.0.1.md5"
 func GetPluginMD5FileName(t *Tool) string {
-	return fmt.Sprintf("%s-%s-%s_%s.md5", t.Plugin.Kind, GOOS, GOARCH, t.Plugin.Version)
+	return fmt.Sprintf("%s-%s-%s_%s.md5", t.Plugin, GOOS, GOARCH, version.Version)
 }
 
 // GetDtmMD5FileName format likes dtm-linux-amd64

--- a/internal/pkg/configloader/configloader_test.go
+++ b/internal/pkg/configloader/configloader_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestDependencyPass(t *testing.T) {
 	tools := []Tool{
-		{Name: "argocd", Plugin: Plugin{Kind: "argocd"}},
-		{Name: "argocdapp", Plugin: Plugin{Kind: "argocdapp"}, DependsOn: []string{"argocd.argocd"}},
+		{Name: "argocd", Plugin: "argocd"},
+		{Name: "argocdapp", Plugin: "argocdapp", DependsOn: []string{"argocd.argocd"}},
 	}
 	errors := validateDependency(tools)
 	assert.Equal(t, len(errors), 0, "Dependency check passed.")
@@ -18,7 +18,7 @@ func TestDependencyPass(t *testing.T) {
 
 func TestDependencyNotExist(t *testing.T) {
 	tools := []Tool{
-		{Name: "argocdapp", Plugin: Plugin{Kind: "argocdapp"}, DependsOn: []string{"argocd.argocd"}},
+		{Name: "argocdapp", Plugin: "argocdapp", DependsOn: []string{"argocd.argocd"}},
 	}
 	errors := validateDependency(tools)
 	assert.Equal(t, len(errors), 1)
@@ -27,9 +27,9 @@ func TestDependencyNotExist(t *testing.T) {
 
 func TestMultipleDependencies(t *testing.T) {
 	tools := []Tool{
-		{Name: "argocd", Plugin: Plugin{Kind: "argocd"}},
-		{Name: "repo", Plugin: Plugin{Kind: "github"}},
-		{Name: "argocdapp", Plugin: Plugin{Kind: "argocdapp"}, DependsOn: []string{"argocd.argocd", "repo.github"}},
+		{Name: "argocd", Plugin: "argocd"},
+		{Name: "repo", Plugin: "github"},
+		{Name: "argocdapp", Plugin: "argocdapp", DependsOn: []string{"argocd.argocd", "repo.github"}},
 	}
 	errors := validateDependency(tools)
 	assert.Equal(t, len(errors), 0)
@@ -37,8 +37,8 @@ func TestMultipleDependencies(t *testing.T) {
 
 func TestEmptyDependency(t *testing.T) {
 	tools := []Tool{
-		{Name: "argocd", Plugin: Plugin{Kind: "argocd"}},
-		{Name: "argocdapp", Plugin: Plugin{Kind: "argocdapp"}, DependsOn: []string{}},
+		{Name: "argocd", Plugin: "argocd"},
+		{Name: "argocdapp", Plugin: "argocdapp", DependsOn: []string{}},
 	}
 	errors := validateDependency(tools)
 	assert.Equal(t, len(errors), 0)

--- a/internal/pkg/configloader/validation.go
+++ b/internal/pkg/configloader/validation.go
@@ -33,8 +33,8 @@ func validateTool(t *Tool) []error {
 	}
 
 	// Plugin
-	if t.Plugin.Kind == "" {
-		errors = append(errors, fmt.Errorf("plugin.kind is empty"))
+	if t.Plugin == "" {
+		errors = append(errors, fmt.Errorf("plugin is empty"))
 	}
 
 	return errors
@@ -47,7 +47,7 @@ func validateDependency(tools []Tool) []error {
 	toolMap := make(map[string]bool)
 	// creating the set
 	for _, tool := range tools {
-		key := fmt.Sprintf("%s.%s", tool.Name, tool.Plugin.Kind)
+		key := fmt.Sprintf("%s.%s", tool.Name, tool.Plugin)
 		toolMap[key] = true
 	}
 

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -26,8 +26,8 @@ type ChangeResult struct {
 }
 
 func (c *Change) String() string {
-	return fmt.Sprintf("\n{\n  ActionName: %s,\n  Tool: {Name: %s, Plugin: {Kind: %s, Version: %s}}\n}",
-		c.ActionName, c.Tool.Name, c.Tool.Plugin.Kind, c.Tool.Plugin.Version)
+	return fmt.Sprintf("\n{\n  ActionName: %s,\n  Tool: {Name: %s, Plugin: %s}}\n}",
+		c.ActionName, c.Tool.Name, c.Tool.Plugin)
 }
 
 type CommandType string
@@ -90,7 +90,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 
 	for i, c := range changes {
 		log.Separatorf("Processing progress: %d/%d.", i+1, numOfChanges)
-		log.Infof("Processing: %s (%s) -> %s ...", c.Tool.Name, c.Tool.Plugin.Kind, c.ActionName)
+		log.Infof("Processing: %s (%s) -> %s ...", c.Tool.Name, c.Tool.Plugin, c.ActionName)
 
 		var succeeded bool
 		var err error
@@ -105,7 +105,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 			for _, e := range errs {
 				log.Errorf("Error: %s.", e)
 			}
-			log.Errorf("The outputs reference in tool %s (%s) can't be resolved. Please double check your config.", c.Tool.Name, c.Tool.Plugin.Kind)
+			log.Errorf("The outputs reference in tool %s (%s) can't be resolved. Please double check your config.", c.Tool.Name, c.Tool.Plugin)
 
 			// not executing this change since its input isn't valid
 			continue
@@ -125,7 +125,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 		}
 
 		if err != nil {
-			key := fmt.Sprintf("%s/%s-%s", c.Tool.Plugin.Kind, c.Tool.Name, c.ActionName)
+			key := fmt.Sprintf("%s/%s-%s", c.Tool.Plugin, c.Tool.Name, c.ActionName)
 			errorsMap[key] = err
 		}
 
@@ -166,7 +166,7 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 			log.Debugf("Failed to delete state %s: %s.", key, err)
 			return err
 		}
-		log.Successf("Plugin %s (%s) delete done.", change.Tool.Name, change.Tool.Plugin.Kind)
+		log.Successf("Plugin %s (%s) delete done.", change.Tool.Name, change.Tool.Plugin)
 		return nil
 	}
 
@@ -182,6 +182,6 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 		log.Debugf("Failed to add state %s: %s.", key, err)
 		return err
 	}
-	log.Successf("Plugin %s(%s) %s done.", change.Tool.Name, change.Tool.Plugin.Kind, change.ActionName)
+	log.Successf("Plugin %s(%s) %s done.", change.Tool.Name, change.Tool.Plugin, change.ActionName)
 	return nil
 }

--- a/internal/pkg/pluginengine/change_helper.go
+++ b/internal/pkg/pluginengine/change_helper.go
@@ -79,7 +79,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 
 			if state == nil {
 				// tool not in the state, create, no need to Read resource before Create
-				description := fmt.Sprintf("Tool %s (%s) found in config but doesn't exist in the state, will be created.", tool.Name, tool.Plugin.Kind)
+				description := fmt.Sprintf("Tool %s (%s) found in config but doesn't exist in the state, will be created.", tool.Name, tool.Plugin)
 				changes = append(changes, generateCreateAction(&tool, description))
 			} else {
 				// tool found in the state
@@ -90,7 +90,7 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 
 				if drifted(tool.Options, state.Options) {
 					// tool's config differs from State's, Update
-					description := fmt.Sprintf("Tool %s (%s) config drifted from the state, will be updated.", tool.Name, tool.Plugin.Kind)
+					description := fmt.Sprintf("Tool %s (%s) config drifted from the state, will be updated.", tool.Name, tool.Plugin)
 					changes = append(changes, generateUpdateAction(&tool, description))
 				} else {
 					// tool's config is the same as State's
@@ -103,15 +103,15 @@ func changesForApply(smgr statemanager.Manager, cfg *configloader.Config) ([]*Ch
 
 					if resource == nil {
 						// tool exists in the state, but resource doesn't exist, Create
-						description := fmt.Sprintf("Tool %s (%s) state found but it seems the tool isn't created, will be created.", tool.Name, tool.Plugin.Kind)
+						description := fmt.Sprintf("Tool %s (%s) state found but it seems the tool isn't created, will be created.", tool.Name, tool.Plugin)
 						changes = append(changes, generateCreateAction(&tool, description))
 					} else if drifted(resource, state.Resource) {
 						// resource drifted from state, Update
-						description := fmt.Sprintf("Tool %s (%s) drifted from the state, will be updated.", tool.Name, tool.Plugin.Kind)
+						description := fmt.Sprintf("Tool %s (%s) drifted from the state, will be updated.", tool.Name, tool.Plugin)
 						changes = append(changes, generateUpdateAction(&tool, description))
 					} else {
 						// resource is the same as the state, do nothing
-						log.Debugf("Tool %s (%s) is the same as the state, do nothing.", tool.Name, tool.Plugin.Kind)
+						log.Debugf("Tool %s (%s) is the same as the state, do nothing.", tool.Name, tool.Plugin)
 					}
 				}
 			}
@@ -146,7 +146,7 @@ func changesForDelete(smgr statemanager.Manager, cfg *configloader.Config) []*Ch
 		if state == nil {
 			continue
 		}
-		description := fmt.Sprintf("Tool %s (%s) will be deleted.", tool.Name, tool.Plugin.Kind)
+		description := fmt.Sprintf("Tool %s (%s) will be deleted.", tool.Name, tool.Plugin)
 		changes = append(changes, generateDeleteAction(&tool, description))
 		tmpStates.Delete(statemanager.StateKeyGenerateFunc(&tool))
 	}
@@ -162,7 +162,7 @@ func changesForForceDelete(smgr statemanager.Manager, cfg *configloader.Config) 
 
 	for i := len(cfg.Tools) - 1; i >= 0; i-- {
 		tool := cfg.Tools[i]
-		description := fmt.Sprintf("Tool %s (%s) will be deleted.", tool.Name, tool.Plugin.Kind)
+		description := fmt.Sprintf("Tool %s (%s) will be deleted.", tool.Name, tool.Plugin)
 		changes = append(changes, generateDeleteAction(&tool, description))
 		if err := smgr.DeleteState(statemanager.StateKeyGenerateFunc(&tool)); err != nil {
 			log.Errorf("Failed to delete %s from state.", statemanager.StateKeyGenerateFunc(&tool))

--- a/internal/pkg/pluginengine/pluginengine_test.go
+++ b/internal/pkg/pluginengine/pluginengine_test.go
@@ -41,69 +41,62 @@ var _ = Describe("Pluginengine", func() {
 	It("should be 'one install'", func() {
 		name := "a"
 		kind := "tool-a"
-		version := "v0.0.1"
 
 		cfg := &configloader.Config{
-			Tools: []configloader.Tool{*getTool(name, kind, version)},
+			Tools: []configloader.Tool{*getTool(name, kind)},
 		}
 		changes, _ := pluginengine.GetChangesForApply(smgr, cfg)
 		GinkgoWriter.Print(changes)
 		Expect(len(changes)).To(Equal(1))
 		c := changes[0]
 		Expect(c.Tool.Name).To(Equal(name))
-		Expect(c.Tool.Plugin.Version).To(Equal(version))
 		Expect(c.ActionName).To(Equal(statemanager.ActionCreate))
 	})
 
 	It("should be 'two install'", func() {
 		name1, name2 := "a", "b"
-		kind1, kind2 := "tool-a", "too-b"
-		version1, version2 := "v0.0.1", "v0.0.2"
+		plugin1, plugin2 := "tool-a", "too-b"
 
 		cfg := &configloader.Config{
-			Tools: []configloader.Tool{*getTool(name1, kind1, version1), *getTool(name2, kind2, version2)},
+			Tools: []configloader.Tool{*getTool(name1, plugin1), *getTool(name2, plugin2)},
 		}
 		changes, _ := pluginengine.GetChangesForApply(smgr, cfg)
 
 		Expect(len(changes)).To(Equal(2))
 		c1 := changes[0]
 		Expect(c1.Tool.Name).To(Equal(name1))
-		Expect(c1.Tool.Plugin.Kind).To(Equal(kind1))
-		Expect(c1.Tool.Plugin.Version).To(Equal(version1))
+		Expect(c1.Tool.Plugin).To(Equal(plugin1))
 		Expect(c1.ActionName).To(Equal(statemanager.ActionCreate))
 
 		c2 := changes[1]
 		Expect(c2.Tool.Name).To(Equal(name2))
-		Expect(c2.Tool.Plugin.Kind).To(Equal(kind2))
-		Expect(c2.Tool.Plugin.Version).To(Equal(version2))
+		Expect(c2.Tool.Plugin).To(Equal(plugin2))
 		Expect(c2.ActionName).To(Equal(statemanager.ActionCreate))
 	})
 
 	It("should be 1 uninstall when `dtm delete` is triggered against a config with 1 tool and a successful state", func() {
 		name := "a"
-		kind := "tool-a"
-		version := "v0.0.1"
+		plugin := "tool-a"
 
 		cfg := &configloader.Config{
-			Tools: []configloader.Tool{*getTool(name, kind, version)},
+			Tools: []configloader.Tool{*getTool(name, plugin)},
 		}
 
-		err = smgr.AddState(statemanager.StateKey(fmt.Sprintf("%s_%s", name, kind)), statemanager.State{})
+		err = smgr.AddState(statemanager.StateKey(fmt.Sprintf("%s_%s", name, plugin)), statemanager.State{})
 		Expect(err).NotTo(HaveOccurred())
 		changes, _ := pluginengine.GetChangesForDelete(smgr, cfg, false)
 
 		Expect(len(changes)).To(Equal(1))
 		c := changes[0]
 		Expect(c.Tool.Name).To(Equal(name))
-		Expect(c.Tool.Plugin.Kind).To(Equal(kind))
-		Expect(c.Tool.Plugin.Version).To(Equal(version))
+		Expect(c.Tool.Plugin).To(Equal(plugin))
 		Expect(c.ActionName).To(Equal(statemanager.ActionDelete))
 	})
 
 	It("should handle outputs correctly", func() {
 		trelloState := statemanager.State{
 			Name:    "mytrelloboard",
-			Plugin:  configloader.Plugin{Kind: "trello", Version: "0.2.0"},
+			Plugin:  "trello",
 			Options: map[string]interface{}{},
 			Resource: map[string]interface{}{
 				"outputs": map[string]interface{}{
@@ -131,7 +124,7 @@ var _ = Describe("Pluginengine", func() {
 	It("should give an error when output doesn't exist in the state", func() {
 		trelloState := statemanager.State{
 			Name:     "mytrelloboard",
-			Plugin:   configloader.Plugin{Kind: "trello", Version: "0.2.0"},
+			Plugin:   "trello",
 			Options:  map[string]interface{}{},
 			Resource: map[string]interface{}{},
 		}
@@ -152,7 +145,7 @@ var _ = Describe("Pluginengine", func() {
 	It("should give an error when the referred key doesn't exist", func() {
 		trelloState := statemanager.State{
 			Name:    "mytrelloboard",
-			Plugin:  configloader.Plugin{Kind: "trello", Version: "0.2.0"},
+			Plugin:  "trello",
 			Options: map[string]interface{}{},
 			Resource: map[string]interface{}{
 				"outputs": map[string]interface{}{
@@ -182,7 +175,7 @@ var _ = Describe("Pluginengine", func() {
 	It("should work for nested maps", func() {
 		trelloState := statemanager.State{
 			Name:    "mytrelloboard",
-			Plugin:  configloader.Plugin{Kind: "trello", Version: "0.2.0"},
+			Plugin:  "trello",
 			Options: map[string]interface{}{},
 			Resource: map[string]interface{}{
 				"outputs": map[string]interface{}{
@@ -209,10 +202,10 @@ var _ = Describe("Pluginengine", func() {
 	})
 })
 
-func getTool(name, kind, version string) *configloader.Tool {
+func getTool(name, kind string) *configloader.Tool {
 	return &configloader.Tool{
 		Name:    name,
-		Plugin:  configloader.Plugin{Kind: kind, Version: version},
+		Plugin:  kind,
 		Options: map[string]interface{}{"key": "value"},
 	}
 }

--- a/internal/pkg/pluginengine/topological_sort.go
+++ b/internal/pkg/pluginengine/topological_sort.go
@@ -8,7 +8,7 @@ import (
 )
 
 func generateKeyFromTool(tool configloader.Tool) string {
-	return fmt.Sprintf("%s.%s", tool.Name, tool.Plugin.Kind)
+	return fmt.Sprintf("%s.%s", tool.Name, tool.Plugin)
 }
 
 func dependencyResolved(tool configloader.Tool, unprocessedNodeSet map[string]bool) bool {
@@ -16,14 +16,14 @@ func dependencyResolved(tool configloader.Tool, unprocessedNodeSet map[string]bo
 
 	for _, dep := range tool.DependsOn {
 		// if the tool's dependency is still not processed yet / still in the graph
-		log.Debugf("TOOL %s.%s dependency NOT solved\n", tool.Name, tool.Plugin.Kind)
+		log.Debugf("TOOL %s.%s dependency NOT solved\n", tool.Name, tool.Plugin)
 		if _, ok := unprocessedNodeSet[dep]; ok {
 			res = false
 			break
 		}
 	}
 
-	log.Debugf("TOOL %s %s %t\n", tool.Name, tool.Plugin.Kind, res)
+	log.Debugf("TOOL %s %s %t\n", tool.Name, tool.Plugin, res)
 	return res
 }
 
@@ -55,11 +55,11 @@ func topologicalSort(tools []configloader.Tool) ([][]configloader.Tool, error) {
 			// if there isn't any dependency: it's the "start" of the graph
 			// we can put it into the first batch
 			if len(tool.DependsOn) == 0 {
-				log.Debugf("TOOL %s.%s dependency already solved\n", tool.Name, tool.Plugin.Kind)
+				log.Debugf("TOOL %s.%s dependency already solved\n", tool.Name, tool.Plugin)
 				batch = append(batch, tool)
 			} else {
 				if dependencyResolved(tool, unprocessedNodeSet) {
-					log.Debugf("TOOL %s.%s dependency already solved\n", tool.Name, tool.Plugin.Kind)
+					log.Debugf("TOOL %s.%s dependency already solved\n", tool.Name, tool.Plugin)
 					batch = append(batch, tool)
 				}
 			}

--- a/internal/pkg/pluginengine/topological_sort_test.go
+++ b/internal/pkg/pluginengine/topological_sort_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestNoDependency(t *testing.T) {
 	tools := []configloader.Tool{
-		{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-		{Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
-		{Name: "c", Plugin: configloader.Plugin{Kind: "c"}},
-		{Name: "d", Plugin: configloader.Plugin{Kind: "d"}},
+		{Name: "a", Plugin: "a"},
+		{Name: "b", Plugin: "b"},
+		{Name: "c", Plugin: "c"},
+		{Name: "d", Plugin: "d"},
 	}
 	expectedRes :=
 		[][]configloader.Tool{
 			{
-				{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-				{Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
-				{Name: "c", Plugin: configloader.Plugin{Kind: "c"}},
-				{Name: "d", Plugin: configloader.Plugin{Kind: "d"}},
+				{Name: "a", Plugin: "a"},
+				{Name: "b", Plugin: "b"},
+				{Name: "c", Plugin: "c"},
+				{Name: "d", Plugin: "d"},
 			},
 		}
 	actualRes, err := topologicalSort(tools)
@@ -32,20 +32,16 @@ func TestNoDependency(t *testing.T) {
 
 func TestSingleDependency(t *testing.T) {
 	tools := []configloader.Tool{
-		{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-		// {Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
-		{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"a.a"}},
-		// {Name: "d", Plugin: configloader.Plugin{Kind: "d"}},
+		{Name: "a", Plugin: "a"},
+		{Name: "c", Plugin: "c", DependsOn: []string{"a.a"}},
 	}
 	expectedRes :=
 		[][]configloader.Tool{
 			{
-				{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-				// {Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
-				// {Name: "d", Plugin: configloader.Plugin{Kind: "d"}},
+				{Name: "a", Plugin: "a"},
 			},
 			{
-				{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"a.a"}},
+				{Name: "c", Plugin: "c", DependsOn: []string{"a.a"}},
 			},
 		}
 	actualRes, err := topologicalSort(tools)
@@ -55,22 +51,22 @@ func TestSingleDependency(t *testing.T) {
 
 func TestMultiDependencies(t *testing.T) {
 	tools := []configloader.Tool{
-		{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-		{Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
-		{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"a.a", "b.b"}},
-		{Name: "d", Plugin: configloader.Plugin{Kind: "d"}, DependsOn: []string{"c.c"}},
+		{Name: "a", Plugin: "a"},
+		{Name: "b", Plugin: "b"},
+		{Name: "c", Plugin: "c", DependsOn: []string{"a.a", "b.b"}},
+		{Name: "d", Plugin: "d", DependsOn: []string{"c.c"}},
 	}
 	expectedRes :=
 		[][]configloader.Tool{
 			{
-				{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-				{Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
+				{Name: "a", Plugin: "a"},
+				{Name: "b", Plugin: "b"},
 			},
 			{
-				{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"a.a", "b.b"}},
+				{Name: "c", Plugin: "c", DependsOn: []string{"a.a", "b.b"}},
 			},
 			{
-				{Name: "d", Plugin: configloader.Plugin{Kind: "d"}, DependsOn: []string{"c.c"}},
+				{Name: "d", Plugin: "d", DependsOn: []string{"c.c"}},
 			},
 		}
 	actualRes, err := topologicalSort(tools)
@@ -80,22 +76,22 @@ func TestMultiDependencies(t *testing.T) {
 
 func TestDependencyLoop(t *testing.T) {
 	tools := []configloader.Tool{
-		{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-		{Name: "b", Plugin: configloader.Plugin{Kind: "b"}, DependsOn: []string{"d.d"}},
-		{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"b.b"}},
-		{Name: "d", Plugin: configloader.Plugin{Kind: "d"}, DependsOn: []string{"c.c"}},
+		{Name: "a", Plugin: "a"},
+		{Name: "b", Plugin: "b", DependsOn: []string{"d.d"}},
+		{Name: "c", Plugin: "c", DependsOn: []string{"b.b"}},
+		{Name: "d", Plugin: "d", DependsOn: []string{"c.c"}},
 	}
 	expectedRes :=
 		[][]configloader.Tool{
 			{
-				{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
-				{Name: "b", Plugin: configloader.Plugin{Kind: "b"}},
+				{Name: "a", Plugin: "a"},
+				{Name: "b", Plugin: "b"},
 			},
 			{
-				{Name: "c", Plugin: configloader.Plugin{Kind: "c"}, DependsOn: []string{"a.a", "b.b"}},
+				{Name: "c", Plugin: "c", DependsOn: []string{"a.a", "b.b"}},
 			},
 			{
-				{Name: "d", Plugin: configloader.Plugin{Kind: "d"}, DependsOn: []string{"c.c"}},
+				{Name: "d", Plugin: "d", DependsOn: []string{"c.c"}},
 			},
 		}
 	actualRes, err := topologicalSort(tools)

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/merico-dev/stream/cmd/devstream/version"
 	"github.com/merico-dev/stream/internal/pkg/configloader"
+	"github.com/merico-dev/stream/internal/pkg/version"
 	"github.com/merico-dev/stream/pkg/util/log"
 	"github.com/merico-dev/stream/pkg/util/md5"
 )
@@ -35,7 +35,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				// download .so file
-				if err := dc.download(pluginDir, pluginFileName, tool.Plugin.Version); err != nil {
+				if err := dc.download(pluginDir, pluginFileName, version.Version); err != nil {
 					return err
 				}
 				log.Successf("[%s] download succeeded.", pluginFileName)
@@ -46,7 +46,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginMD5FileName)); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				// download .md5 file
-				if err := dc.download(pluginDir, pluginMD5FileName, tool.Plugin.Version); err != nil {
+				if err := dc.download(pluginDir, pluginMD5FileName, version.Version); err != nil {
 					return err
 				}
 				log.Successf("[%s] download succeeded.", pluginMD5FileName)
@@ -65,7 +65,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 		}
 		// if existing .so doesn't matches with .md5, re-download
 		log.Infof("Plugin: %s doesn't match with .md5 and will be downloaded.", pluginFileName)
-		if err := redownloadPlugins(dc, pluginDir, pluginFileName, pluginMD5FileName, tool.Plugin.Version); err != nil {
+		if err := redownloadPlugins(dc, pluginDir, pluginFileName, pluginMD5FileName, version.Version); err != nil {
 			return err
 		}
 

--- a/internal/pkg/pluginmanager/pluginmd5_test.go
+++ b/internal/pkg/pluginmanager/pluginmd5_test.go
@@ -22,7 +22,7 @@ var _ = Describe("CheckLocalPlugins", func() {
 		BeforeEach(func() {
 			viper.Set("plugin-dir", "./")
 			tools = []configloader.Tool{
-				{Name: "a", Plugin: configloader.Plugin{Kind: "a"}},
+				{Name: "a", Plugin: "a"},
 			}
 			config = &configloader.Config{Tools: tools}
 

--- a/internal/pkg/statemanager/manager_test.go
+++ b/internal/pkg/statemanager/manager_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/merico-dev/stream/internal/pkg/backend/local"
-	"github.com/merico-dev/stream/internal/pkg/configloader"
 	"github.com/merico-dev/stream/internal/pkg/statemanager"
 )
 
@@ -26,7 +25,7 @@ var _ = Describe("Statemanager", func() {
 			key := statemanager.StateKey("name_githubactions")
 			stateA := statemanager.State{
 				Name:     "name",
-				Plugin:   configloader.Plugin{Kind: "githubactions", Version: "0.0.2"},
+				Plugin:   "githubactions",
 				Options:  map[string]interface{}{"a": "value"},
 				Resource: map[string]interface{}{"a": "value"},
 			}

--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -14,7 +14,7 @@ import (
 // State is the single component's state.
 type State struct {
 	Name     string
-	Plugin   configloader.Plugin
+	Plugin   string
 	Options  map[string]interface{}
 	Resource map[string]interface{}
 }
@@ -65,7 +65,7 @@ func (s StatesMap) Format() []byte {
 type StateKey string
 
 func StateKeyGenerateFunc(t *configloader.Tool) StateKey {
-	return StateKey(fmt.Sprintf("%s_%s", t.Name, t.Plugin.Kind))
+	return StateKey(fmt.Sprintf("%s_%s", t.Name, t.Plugin))
 }
 
 func GenerateStateKeyByToolNameAndPluginKind(toolName string, pluginKind string) StateKey {

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// Version is the version of DevStream.
+// Assign the value when building with the -X parameter. Example:
+// -X github.com/merico-dev/stream/internal/pkg/version.Version=${VERSION}
+// See the Makefile for more info.
+var Version string


### PR DESCRIPTION
# Summary

Remove "version" from "plugin" in the config.

## Key Points

- [x] This is a breaking change.
- [ ] Documentation (new or existing) is updated.

_Doc hasn't been updated yet._

## Description

Since core and plugin must be built at the same time, the "version" is redundant information now in the config.

### Current Behavior

Config:

```yaml
tools:
- name: ABC
  plugin:
    kind: argocd
    version: 0.3.0
```


### New Behavior

Config:

```yaml
tools:
- name: ABC
  plugin: argocd
```