### PR TITLE
fix: install goimports at `main builder` & `automated-release` workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

fix: install goimports at `main builder` & `automated-release` workflow

### Related pr

#368 


